### PR TITLE
Bug fixes: amend DCO sign-off and pass data structures to the submission routes

### DIFF
--- a/src/app/api/pr/knowledge/route.ts
+++ b/src/app/api/pr/knowledge/route.ts
@@ -29,16 +29,10 @@ export async function POST(req: NextRequest) {
 
   try {
     const body = await req.json();
-    const { content, name, email, submission_summary, title_work, link_work, revision, license_work, creators } = body;
+    const { content, name, email, submission_summary, attribution, filePath } = body;
 
     const knowledgeData: KnowledgeYamlData = yaml.load(content) as KnowledgeYamlData;
-    const attributionData: AttributionData = {
-      title_of_work: title_work,
-      link_to_work: link_work,
-      revision: revision,
-      license_of_the_work: license_work,
-      creator_names: creators
-    };
+    const attributionData: AttributionData = attribution;
 
     // Fetch GitHub username
     const githubUsername = await getGitHubUsername(headers);
@@ -54,8 +48,8 @@ export async function POST(req: NextRequest) {
     }
 
     const branchName = `knowledge-contribution-${Date.now()}`;
-    const newYamlFilePath = `knowledge/${githubUsername.replace(/ /g, '_')}-${Date.now()}.yaml`;
-    const newAttributionFilePath = `knowledge/${githubUsername.replace(/ /g, '_')}-attribution.txt`;
+    const newYamlFilePath = `${filePath}qna.yaml`;
+    const newAttributionFilePath = `${filePath}attribution.txt`;
 
     const yamlString = yaml.dump(knowledgeData, { lineWidth: YamlLineLength });
     const attributionContent = `Title of work: ${attributionData.title_of_work}

--- a/src/app/api/pr/knowledge/route.ts
+++ b/src/app/api/pr/knowledge/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import { NextRequest } from 'next/server';
 import yaml from 'js-yaml';
-import { SchemaVersion } from '@/types';
+import { KnowledgeYamlData, AttributionData, YamlLineLength } from '@/types';
 
 const GITHUB_API_URL = 'https://api.github.com';
 const UPSTREAM_REPO_OWNER = process.env.NEXT_PUBLIC_TAXONOMY_REPO_OWNER!;
@@ -29,23 +29,16 @@ export async function POST(req: NextRequest) {
 
   try {
     const body = await req.json();
-    const {
-      name,
-      email,
-      task_description,
-      submission_summary,
-      domain,
-      repo,
-      commit,
-      patterns,
-      questions,
-      answers,
-      title_work,
-      link_work,
-      revision,
-      license_work,
-      creators
-    } = body;
+    const { content, name, email, submission_summary, title_work, link_work, revision, license_work, creators } = body;
+
+    const knowledgeData: KnowledgeYamlData = yaml.load(content) as KnowledgeYamlData;
+    const attributionData: AttributionData = {
+      title_of_work: title_work,
+      link_to_work: link_work,
+      revision: revision,
+      license_of_the_work: license_work,
+      creator_names: creators
+    };
 
     // Fetch GitHub username
     const githubUsername = await getGitHubUsername(headers);
@@ -56,51 +49,20 @@ export async function POST(req: NextRequest) {
     if (!forkExists) {
       await createFork(headers);
       // Add a delay to ensure the fork operation completes to avoid a race condition when retrieving the base SHA
-      // This only occurs if this is the first time submitting and the fork isn't present.
-      // TODO change to a retry
       console.log('Pause 5s for the forking operation to complete');
       await new Promise((resolve) => setTimeout(resolve, 5000));
     }
 
     const branchName = `knowledge-contribution-${Date.now()}`;
-    const newYamlFilePath = `knowledge/${name.replace(/ /g, '_')}-${Date.now()}.yaml`;
-    const newAttributionFilePath = `knowledge/${name.replace(/ /g, '_')}-attribution.txt`;
+    const newYamlFilePath = `knowledge/${githubUsername.replace(/ /g, '_')}-${Date.now()}.yaml`;
+    const newAttributionFilePath = `knowledge/${githubUsername.replace(/ /g, '_')}-attribution.txt`;
 
-    interface SeedExample {
-      question: string;
-      answer: string;
-    }
-
-    interface Document {
-      repo: string;
-      commit: string;
-      patterns: string[];
-    }
-
-    const yamlData = {
-      created_by: githubUsername,
-      version: SchemaVersion,
-      domain: domain,
-      task_description: task_description,
-      seed_examples: questions.map((question: string, index: number) => {
-        return {
-          question,
-          answer: answers[index]
-        } as SeedExample;
-      }),
-      document: {
-        repo: repo,
-        commit: commit,
-        patterns: patterns.split(',').map((pattern: string) => pattern.trim())
-      } as Document
-    };
-
-    const yamlString = yaml.dump(yamlData, { lineWidth: -1 });
-    const attributionContent = `Title of work: ${title_work}
-Link to work: ${link_work}
-Revision: ${revision}
-License of the work: ${license_work}
-Creator names: ${creators}
+    const yamlString = yaml.dump(knowledgeData, { lineWidth: YamlLineLength });
+    const attributionContent = `Title of work: ${attributionData.title_of_work}
+Link to work: ${attributionData.link_to_work}
+Revision: ${attributionData.revision}
+License of the work: ${attributionData.license_of_the_work}
+Creator names: ${attributionData.creator_names}
 `;
 
     // Get the base branch SHA

--- a/src/app/api/pr/skill/route.ts
+++ b/src/app/api/pr/skill/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import { NextRequest } from 'next/server';
 import yaml from 'js-yaml';
-import { SchemaVersion } from '@/types';
+import { YamlLineLength, SkillYamlData } from '@/types';
 
 const GITHUB_API_URL = 'https://api.github.com';
 const UPSTREAM_REPO_OWNER = process.env.NEXT_PUBLIC_TAXONOMY_REPO_OWNER!;
@@ -29,9 +29,8 @@ export async function POST(req: NextRequest) {
 
   try {
     const body = await req.json();
-    const { name, email, task_description, submission_summary, title_work, link_work, license_work, creators, questions, contexts, answers } = body;
+    const { content, attribution, name, email, submission_summary } = body;
 
-    // Fetch GitHub username
     const githubUsername = await getGitHubUsername(headers);
     console.log('GitHub Username:', githubUsername);
 
@@ -45,35 +44,9 @@ export async function POST(req: NextRequest) {
     const newYamlFilePath = `skills/${name.replace(/ /g, '_')}-qna.yaml`;
     const newAttributionFilePath = `skills/${name.replace(/ /g, '_')}-attribution.txt`;
 
-    interface SeedExample {
-      question: string;
-      answer: string;
-      context?: string;
-    }
-
-    const yamlData = {
-      created_by: githubUsername,
-      version: SchemaVersion,
-      task_description: task_description,
-      seed_examples: questions.map((question: string, index: number) => {
-        const example: SeedExample = {
-          question,
-          answer: answers[index]
-        };
-        if (contexts[index].trim() !== '') {
-          example.context = contexts[index];
-        }
-        return example;
-      })
-    };
-
-    const yamlString = yaml.dump(yamlData, { lineWidth: -1 });
-    const attributionContent = `Title of work: ${title_work}
-Link to work: ${link_work}
-Revision: -
-License of the work: ${license_work}
-Creator names: ${creators}
-`;
+    const skillData = yaml.load(content) as SkillYamlData;
+    const attributionData = attribution;
+    const yamlString = yaml.dump(skillData, { lineWidth: YamlLineLength });
 
     // Get the base branch SHA
     const baseBranchSha = await getBaseBranchSha(headers, githubUsername);
@@ -88,7 +61,7 @@ Creator names: ${creators}
       githubUsername,
       [
         { path: newYamlFilePath, content: yamlString },
-        { path: newAttributionFilePath, content: attributionContent }
+        { path: newAttributionFilePath, content: attributionData }
       ],
       branchName,
       `${submission_summary}\n\nSigned-off-by: ${name} <${email}>`

--- a/src/app/edit-submission/knowledge/[id]/page.tsx
+++ b/src/app/edit-submission/knowledge/[id]/page.tsx
@@ -94,7 +94,6 @@ const EditPullRequestPage: React.FunctionComponent<{ params: { id: string } }> =
           console.log('Parsed YAML data:', yamlData);
 
           // Populate the form fields with YAML data
-          setEmail(yamlData.created_by);
           setTaskDescription(yamlData.task_description);
           setDomain(yamlData.domain);
           setRepo(yamlData.document.repo);
@@ -135,7 +134,7 @@ const EditPullRequestPage: React.FunctionComponent<{ params: { id: string } }> =
   }, [session, number, params]);
 
   const handleSave = async () => {
-    if (session?.accessToken && yamlFile && attributionFile && branchName) {
+    if (session?.accessToken && yamlFile && attributionFile && branchName && email && name) {
       try {
         console.log(`Updating PR with number: ${number}`);
         await updatePullRequest(session.accessToken, number, { title, body });
@@ -174,8 +173,8 @@ Creator names: ${creators}
 
         console.log('Updated Attribution content:', updatedAttributionContent);
 
-        // Update the commit by amending it with the new content
-        console.log(`Amending commit with updated content`);
+        const commitMessage = `Amend commit with updated content\n\nSigned-off-by: ${name} <${email}>`;
+
         const amendedCommitResponse = await amendCommit(
           session.accessToken,
           githubUsername,
@@ -183,7 +182,8 @@ Creator names: ${creators}
           { yaml: yamlFile.filename, attribution: attributionFile.filename },
           updatedYamlContent,
           updatedAttributionContent,
-          branchName
+          branchName,
+          commitMessage
         );
         console.log('Amended commit response:', amendedCommitResponse);
 
@@ -207,7 +207,7 @@ Creator names: ${creators}
       }
     } else {
       setFailureAlertTitle('Error');
-      setFailureAlertMessage('YAML file, Attribution file, or branch name is missing.');
+      setFailureAlertMessage('YAML file, Attribution file, branch name, email, or name is missing.');
       setIsFailureAlertVisible(true);
     }
   };
@@ -338,19 +338,19 @@ Creator names: ${creators}
             <FormGroup isRequired key={'author-info-details-id'}>
               <TextInput
                 isRequired
-                type="email"
-                aria-label="email"
-                placeholder="Enter your github ID"
-                value={email}
-                onChange={(_event, value) => setEmail(value)}
-              />
-              <TextInput
-                isRequired
                 type="text"
                 aria-label="name"
                 placeholder="Enter your full name"
                 value={name}
                 onChange={(_event, value) => setName(value)}
+              />
+              <TextInput
+                isRequired
+                type="email"
+                aria-label="email"
+                placeholder="Enter your email address"
+                value={email}
+                onChange={(_event, value) => setEmail(value)}
               />
             </FormGroup>
           </FormFieldGroupExpandable>

--- a/src/app/edit-submission/knowledge/[id]/page.tsx
+++ b/src/app/edit-submission/knowledge/[id]/page.tsx
@@ -18,7 +18,7 @@ import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
 import { Text } from '@patternfly/react-core/dist/dynamic/components/Text';
 import { AppLayout } from '../../../../components/AppLayout';
 import { UploadFile } from '../../../../components/Contribute/Knowledge/UploadFile';
-import { AttributionData, PullRequestFile, KnowledgeYamlData, SchemaVersion } from '@/types';
+import { AttributionData, PullRequestFile, KnowledgeYamlData, SchemaVersion, YamlLineLength } from '@/types';
 import {
   fetchPullRequest,
   fetchFileContent,
@@ -159,11 +159,10 @@ const EditPullRequestPage: React.FunctionComponent<{ params: { id: string } }> =
           }))
         };
         const updatedYamlContent = yaml.dump(updatedYamlData, {
-          lineWidth: -1,
+          lineWidth: YamlLineLength,
           noCompatMode: true,
           quotingType: '"'
         });
-
         console.log('Updated YAML content:', updatedYamlContent);
 
         const updatedAttributionContent = `Title of work: ${title_work}

--- a/src/app/edit-submission/skill/[id]/page.tsx
+++ b/src/app/edit-submission/skill/[id]/page.tsx
@@ -17,7 +17,7 @@ import { ActionGroup } from '@patternfly/react-core/dist/dynamic/components/Form
 import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
 import { Text } from '@patternfly/react-core/dist/dynamic/components/Text';
 import { AppLayout } from '../../../../components/AppLayout';
-import { AttributionData, PullRequestFile, SchemaVersion, SkillYamlData } from '@/types';
+import { AttributionData, PullRequestFile, SchemaVersion, SkillYamlData, YamlLineLength } from '@/types';
 import {
   fetchPullRequest,
   fetchFileContent,
@@ -143,7 +143,7 @@ const EditSkillPage: React.FunctionComponent<{ params: { id: string } }> = ({ pa
           }))
         };
         const updatedYamlContent = yaml.dump(updatedYamlData, {
-          lineWidth: -1,
+          lineWidth: YamlLineLength,
           noCompatMode: true,
           quotingType: '"'
         });

--- a/src/app/edit-submission/skill/[id]/page.tsx
+++ b/src/app/edit-submission/skill/[id]/page.tsx
@@ -35,6 +35,7 @@ const EditSkillPage: React.FunctionComponent<{ params: { id: string } }> = ({ pa
   const [body, setBody] = React.useState('');
   const [email, setEmail] = React.useState('');
   const [name, setName] = React.useState('');
+  // const [githubId, setGithubId] = React.useState('');
   const [task_description, setTaskDescription] = React.useState('');
   const [title_work, setTitleWork] = React.useState('');
   const [link_work, setLinkWork] = React.useState('-');
@@ -87,7 +88,6 @@ const EditSkillPage: React.FunctionComponent<{ params: { id: string } }> = ({ pa
           console.log('Parsed YAML data:', yamlData);
 
           // Populate the form fields with YAML data
-          setEmail(yamlData.created_by);
           setTaskDescription(yamlData.task_description);
           setQuestions(yamlData.seed_examples.map((example) => example.question));
           setContexts(yamlData.seed_examples.map((example) => example.context || ''));
@@ -109,6 +109,9 @@ const EditSkillPage: React.FunctionComponent<{ params: { id: string } }> = ({ pa
             setLicenseWork(attributionData.license_of_the_work);
             setCreators(attributionData.creator_names);
           }
+
+          // const githubUsername = await getGitHubUsername(session.accessToken);
+          // setGithubId(githubUsername);
         } catch (error) {
           if (axios.isAxiosError(error)) {
             console.error('Error fetching pull request data:', error.response ? error.response.data : error.message);
@@ -124,7 +127,7 @@ const EditSkillPage: React.FunctionComponent<{ params: { id: string } }> = ({ pa
   }, [session, number, params]);
 
   const handleSave = async () => {
-    if (session?.accessToken && yamlFile && attributionFile && branchName) {
+    if (session?.accessToken && yamlFile && attributionFile && branchName && email && name) {
       try {
         console.log(`Updating PR with number: ${number}`);
         await updatePullRequest(session.accessToken, number, { title, body });
@@ -159,8 +162,8 @@ Creator names: ${creators}
 
         console.log('Updated Attribution content:', updatedAttributionContent);
 
-        // Update the commit by amending it with the new content
-        console.log(`Amending commit with updated content`);
+        const commitMessage = `Amend commit with updated content\n\nSigned-off-by: ${name} <${email}>`;
+
         const amendedCommitResponse = await amendCommit(
           session.accessToken,
           githubUsername,
@@ -168,7 +171,8 @@ Creator names: ${creators}
           { yaml: yamlFile.filename, attribution: attributionFile.filename },
           updatedYamlContent,
           updatedAttributionContent,
-          branchName
+          branchName,
+          commitMessage
         );
         console.log('Amended commit response:', amendedCommitResponse);
 
@@ -192,7 +196,7 @@ Creator names: ${creators}
       }
     } else {
       setFailureAlertTitle('Error');
-      setFailureAlertMessage('YAML file, Attribution file, or branch name is missing.');
+      setFailureAlertMessage('YAML file, Attribution file, branch name, email, or name is missing.');
       setIsFailureAlertVisible(true);
     }
   };
@@ -280,19 +284,19 @@ Creator names: ${creators}
             <FormGroup isRequired key={'author-info-details-id'}>
               <TextInput
                 isRequired
-                type="email"
-                aria-label="email"
-                placeholder="Enter your github ID"
-                value={email}
-                onChange={(_event, value) => setEmail(value)}
-              />
-              <TextInput
-                isRequired
                 type="text"
                 aria-label="name"
                 placeholder="Enter your full name"
                 value={name}
                 onChange={(_event, value) => setName(value)}
+              />
+              <TextInput
+                isRequired
+                type="email"
+                aria-label="email"
+                placeholder="Enter your email address"
+                value={email}
+                onChange={(_event, value) => setEmail(value)}
               />
             </FormGroup>
           </FormFieldGroupExpandable>

--- a/src/components/Contribute/Knowledge/index.tsx
+++ b/src/components/Contribute/Knowledge/index.tsx
@@ -17,7 +17,7 @@ import { getGitHubUsername } from '../../../utils/github';
 import { useSession } from 'next-auth/react';
 import YamlCodeModal from '../../YamlCodeModal';
 import { UploadFile } from './UploadFile';
-import { SchemaVersion } from '@/types';
+import { SchemaVersion, YamlLineLength } from '@/types';
 import KnowledgeDescription from './KnowledgeDescription';
 
 export const KnowledgeForm: React.FunctionComponent = () => {
@@ -200,13 +200,15 @@ export const KnowledgeForm: React.FunctionComponent = () => {
       answers
     };
 
+    const yamlString = yaml.dump(knowledgeData, { lineWidth: YamlLineLength });
+
     try {
       const response = await fetch('/api/pr/knowledge', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify(knowledgeData)
+        body: JSON.stringify({ content: yamlString })
       });
 
       if (!response.ok) {
@@ -350,7 +352,7 @@ export const KnowledgeForm: React.FunctionComponent = () => {
       }
     };
 
-    const yamlString = yaml.dump(yamlData, { lineWidth: -1 });
+    const yamlString = yaml.dump(yamlData, { lineWidth: YamlLineLength });
     const blob = new Blob([yamlString], { type: 'application/x-yaml' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -406,7 +408,7 @@ Creator names: ${creators}
       }
     };
 
-    const yamlString = yaml.dump(yamlData, { lineWidth: -1 });
+    const yamlString = yaml.dump(yamlData, { lineWidth: YamlLineLength });
     setYamlContent(yamlString);
     setIsModalOpen(true);
   };

--- a/src/components/Contribute/Skill/index.tsx
+++ b/src/components/Contribute/Skill/index.tsx
@@ -16,7 +16,7 @@ import yaml from 'js-yaml';
 import { getGitHubUsername } from '../../../utils/github';
 import { useSession } from 'next-auth/react';
 import YamlCodeModal from '../../YamlCodeModal';
-import { SchemaVersion } from '@/types';
+import { SchemaVersion, YamlLineLength } from '@/types';
 import SkillDescription from './SkillDescription';
 
 export const SkillForm: React.FunctionComponent = () => {
@@ -185,13 +185,15 @@ export const SkillForm: React.FunctionComponent = () => {
       answers
     };
 
+    const yamlString = yaml.dump(skillData, { lineWidth: YamlLineLength });
+
     try {
       const response = await fetch('/api/pr/skill', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify(skillData)
+        body: JSON.stringify({ content: yamlString })
       });
 
       if (!response.ok) {
@@ -224,7 +226,8 @@ export const SkillForm: React.FunctionComponent = () => {
       }))
     };
 
-    const yamlString = yaml.dump(yamlData, { lineWidth: -1 });
+    const yamlString = yaml.dump(yamlData, { lineWidth: YamlLineLength });
+
     setYamlContent(yamlString);
     setIsModalOpen(true);
   };
@@ -295,7 +298,7 @@ export const SkillForm: React.FunctionComponent = () => {
       })
     };
 
-    const yamlString = yaml.dump(yamlData, { lineWidth: -1 });
+    const yamlString = yaml.dump(yamlData, { lineWidth: YamlLineLength });
     const blob = new Blob([yamlString], { type: 'application/x-yaml' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 // src/types/index.ts
 
 export const SchemaVersion = 2;
+export const YamlLineLength = 80;
 
 export interface Endpoint {
   id: string;

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -117,14 +117,15 @@ export const amendCommit = async (
   token: string,
   username: string,
   repoName: string,
-  filePath: { yaml: string; attribution: string },
+  oldFilePath: { yaml: string; attribution: string }, // If the user changed the taxonomy file path on edit, adjust the amendment
+  newFilePath: { yaml: string; attribution: string },
   updatedYamlContent: string,
   updatedAttributionContent: string,
   branch: string,
   commitMessage: string
 ) => {
   try {
-    console.log(`Amending commit for path: ${filePath} in repo: ${repoName}`);
+    console.log(`Amending commit for path: ${oldFilePath} in repo: ${repoName}`);
 
     // Step 1: Get the latest commit SHA for the branch
     const branchResponse = await axios.get(`https://api.github.com/repos/${username}/${repoName}/git/refs/heads/${branch}`, {
@@ -181,25 +182,45 @@ export const amendCommit = async (
     const attributionBlobSha = attributionBlobResponse.data.sha;
     console.log(`New Attribution blob SHA: ${attributionBlobSha}`);
 
-    // Step 4: Create a new tree with the updated blobs
+    // Step 4: Create a new tree with the updated blobs and remove old files if path changed
+    const tree = [
+      {
+        path: newFilePath.yaml,
+        mode: '100644',
+        type: 'blob',
+        sha: yamlBlobSha
+      },
+      {
+        path: newFilePath.attribution,
+        mode: '100644',
+        type: 'blob',
+        sha: attributionBlobSha
+      }
+    ];
+
+    if (oldFilePath.yaml !== newFilePath.yaml) {
+      tree.push({
+        path: oldFilePath.yaml,
+        mode: '100644',
+        type: 'blob',
+        sha: null
+      });
+    }
+
+    if (oldFilePath.attribution !== newFilePath.attribution) {
+      tree.push({
+        path: oldFilePath.attribution,
+        mode: '100644',
+        type: 'blob',
+        sha: null
+      });
+    }
+
     const newTreeResponse = await axios.post(
       `https://api.github.com/repos/${username}/${repoName}/git/trees`,
       {
         base_tree: treeSha,
-        tree: [
-          {
-            path: filePath.yaml,
-            mode: '100644',
-            type: 'blob',
-            sha: yamlBlobSha
-          },
-          {
-            path: filePath.attribution,
-            mode: '100644',
-            type: 'blob',
-            sha: attributionBlobSha
-          }
-        ]
+        tree
       },
       {
         headers: {

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -120,7 +120,8 @@ export const amendCommit = async (
   filePath: { yaml: string; attribution: string },
   updatedYamlContent: string,
   updatedAttributionContent: string,
-  branch: string
+  branch: string,
+  commitMessage: string
 ) => {
   try {
     console.log(`Amending commit for path: ${filePath} in repo: ${repoName}`);
@@ -214,7 +215,7 @@ export const amendCommit = async (
     const newCommitResponse = await axios.post(
       `https://api.github.com/repos/${username}/${repoName}/git/commits`,
       {
-        message: `Amend commit with updated content`,
+        message: commitMessage,
         tree: newTreeSha,
         parents: [parentSha]
       },


### PR DESCRIPTION
- Set the length in yaml.dump to enforce a multiline formatting.
- Pass interfaces to the submission APIs to clean up the number of arguments sent and reduce bad code, e.g. `KnowledgeYamlData` and `SkillYamlData` along with `AttributionData`.
- Fix amend submissions to add DCO sign-off.
- Have the user add an email to their edit submission because a GitHub account does not have to have an associated email to look up. Same with name for DCO.
- Add the ability for the user to specify the submission file path. Sanitizes the file path to be usable. On edit, the file path is pulled in for editing from the existing PR. If amended, the files are added to the new git tree with the new file path. Example: https://github.com/brents-pet-robot/taxonomy-sub-testing/pull/117/files

Closes #47 
Closes #42 
Closes #32 

Apologies for cramming so many things in this PR but each issue would be a rebase on the same files and with the target date of tomorrow.. ¯\\_(ツ)_/¯