### PR TITLE
removing the css for the individual buttons within the action group and let the form do the styling

### DIFF
--- a/src/components/Contribute/Knowledge/index.tsx
+++ b/src/components/Contribute/Knowledge/index.tsx
@@ -676,13 +676,13 @@ Creator names: ${creators}
       )}
 
       <ActionGroup>
-        <Button variant="primary" type="submit" className="submit-k" onClick={handleSubmit}>
+        <Button variant="primary" type="submit" onClick={handleSubmit}>
           Submit Knowledge
         </Button>
-        <Button variant="primary" type="button" className="download-k-yaml" onClick={handleDownloadYaml}>
+        <Button variant="primary" type="button" onClick={handleDownloadYaml}>
           Download YAML
         </Button>
-        <Button variant="primary" type="button" className="download-k-attribution" onClick={handleDownloadAttribution}>
+        <Button variant="primary" type="button" onClick={handleDownloadAttribution}>
           Download Attribution
         </Button>
       </ActionGroup>

--- a/src/components/Contribute/Knowledge/knowledge.css
+++ b/src/components/Contribute/Knowledge/knowledge.css
@@ -6,7 +6,6 @@
   margin-bottom: 50px;
 }
 
-.submit-k,
 .download-k {
   display: inline-block;
   margin-top: 30px;

--- a/src/components/Contribute/Knowledge/knowledge.css
+++ b/src/components/Contribute/Knowledge/knowledge.css
@@ -6,11 +6,6 @@
   margin-bottom: 50px;
 }
 
-.download-k {
-  display: inline-block;
-  margin-top: 30px;
-  margin-left: 50%;
-}
 
 .submit-k:hover,
 .download-k-yaml:hover,

--- a/src/components/Contribute/Skill/index.tsx
+++ b/src/components/Contribute/Skill/index.tsx
@@ -514,13 +514,13 @@ export const SkillForm: React.FunctionComponent = () => {
         </Alert>
       )}
       <ActionGroup>
-        <Button variant="primary" type="submit" className="submit" onClick={handleSubmit}>
+        <Button variant="primary" type="submit" onClick={handleSubmit}>
           Submit Skill
         </Button>
-        <Button variant="primary" type="button" className="download-yaml" onClick={handleDownloadYaml}>
+        <Button variant="primary" type="button" onClick={handleDownloadYaml}>
           Download YAML
         </Button>
-        <Button variant="primary" type="button" className="download-attribution" onClick={handleDownloadAttribution}>
+        <Button variant="primary" type="button" onClick={handleDownloadAttribution}>
           Download Attribution
         </Button>
       </ActionGroup>

--- a/src/components/Contribute/Skill/skill.css
+++ b/src/components/Contribute/Skill/skill.css
@@ -6,13 +6,6 @@
   margin-bottom: 50px;
 }
 
-.submit,
-.download {
-  display: inline-block;
-  margin-top: 30px;
-  margin-left: 50%;
-}
-
 .submit:hover,
 .download-yaml:hover,
 .download-attribution:hover {


### PR DESCRIPTION
This does not solve the discrepancy regarding why the dev and prod css is different. However, the buttons now look a consistent style by removing the specific class for the buttons