### PR TITLE
Instructions for dev markdown file linting

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -67,6 +67,16 @@ npm run pretty
 
 # Run type checking
 npm run type-check
+
+```
+
+## Make scripts
+
+Podman is a requirement. Install and init instructions [here](https://podman.io/docs/installation).
+
+```bash
+# Run markdown linter
+make md-lint
 ```
 
 ### Summary of Server-Side Rendering and Client-Side Data Handling for Jobs and Chat Routes


### PR DESCRIPTION
Section in the development.md instructions for running the markdown linter via makefile. Also link out to podman instructions which is a dependency of this functionality.