### PR TITLE
UI Crash on clear chat button fix

### DIFF
--- a/src/app/playground/chat/page.tsx
+++ b/src/app/playground/chat/page.tsx
@@ -171,9 +171,7 @@ const ChatPage: React.FC = () => {
 
                     setMessages((messages) => {
                       const updatedMessages = [...messages];
-                      if (updatedMessages.length > 1) {
-                        updatedMessages[updatedMessages.length - 1].text = botMessage;
-                      } 
+                      updatedMessages[updatedMessages.length - 1].text = botMessage;
                       return updatedMessages;
                     });
                   }

--- a/src/app/playground/chat/page.tsx
+++ b/src/app/playground/chat/page.tsx
@@ -171,7 +171,9 @@ const ChatPage: React.FC = () => {
 
                     setMessages((messages) => {
                       const updatedMessages = [...messages];
-                      updatedMessages[updatedMessages.length - 1].text = botMessage;
+                      if (updatedMessages.length > 1) {
+                        updatedMessages[updatedMessages.length - 1].text = botMessage;
+                      }
                       return updatedMessages;
                     });
                   }

--- a/src/app/playground/chat/page.tsx
+++ b/src/app/playground/chat/page.tsx
@@ -171,7 +171,9 @@ const ChatPage: React.FC = () => {
 
                     setMessages((messages) => {
                       const updatedMessages = [...messages];
-                      updatedMessages[updatedMessages.length - 1].text = botMessage;
+                      if (updatedMessages.length > 1) {
+                        updatedMessages[updatedMessages.length - 1].text = botMessage;
+                      } 
                       return updatedMessages;
                     });
                   }


### PR DESCRIPTION
on merge, close #124 

When clicking the clear text button mid answer, the application won't crash anymore.

However it is still generating the answer, so when another question is asked, it will continue answering the previous question.

e.g. I asked to give a short description of Sherlock Holmes before clearing the text.

![image](https://github.com/user-attachments/assets/371fb406-2e05-45bb-94fe-07dc7191db6a)
