### PR TITLE
Knowledge and Skill contribution fails if the initial

### DIFF
--- a/src/app/api/pr/knowledge/route.ts
+++ b/src/app/api/pr/knowledge/route.ts
@@ -4,13 +4,13 @@ import { getToken } from 'next-auth/jwt';
 import { NextRequest } from 'next/server';
 import yaml from 'js-yaml';
 import { KnowledgeYamlData, AttributionData } from '@/types';
+import { GITHUB_API_URL, BASE_BRANCH } from '@/types/const';
 import { dumpYaml } from '@/utils/yamlConfig';
+import { checkUserForkExists, createBranch, createFilesInSingleCommit, createFork, getBaseBranchSha, getGitHubUsername } from '@/utils/github';
 
-const GITHUB_API_URL = 'https://api.github.com';
 const KNOWLEDGE_DIR = 'knowledge';
 const UPSTREAM_REPO_OWNER = process.env.NEXT_PUBLIC_TAXONOMY_REPO_OWNER!;
 const UPSTREAM_REPO_NAME = process.env.NEXT_PUBLIC_TAXONOMY_REPO!;
-const BASE_BRANCH = 'main';
 
 export async function POST(req: NextRequest) {
   const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET! });
@@ -40,12 +40,9 @@ export async function POST(req: NextRequest) {
     console.log('GitHub Username:', githubUsername);
 
     // Check if user's fork exists, if not, create it
-    const forkExists = await checkUserForkExists(headers, githubUsername);
+    const forkExists = await checkUserForkExists(headers, githubUsername, UPSTREAM_REPO_NAME);
     if (!forkExists) {
-      await createFork(headers);
-      // Add a delay to ensure the fork operation completes to avoid a race condition when retrieving the base SHA
-      console.log('Pause 5s for the forking operation to complete');
-      await new Promise((resolve) => setTimeout(resolve, 5000));
+      await createFork(headers, UPSTREAM_REPO_OWNER, UPSTREAM_REPO_NAME, githubUsername);
     }
 
     const branchName = `knowledge-contribution-${Date.now()}`;
@@ -62,16 +59,17 @@ Creator names: ${attributionData.creator_names}
 `;
 
     // Get the base branch SHA
-    const baseBranchSha = await getBaseBranchSha(headers, githubUsername);
+    const baseBranchSha = await getBaseBranchSha(headers, githubUsername, UPSTREAM_REPO_NAME);
     console.log(`Base branch SHA: ${baseBranchSha}`);
 
     // Create a new branch in the user's fork
-    await createBranch(headers, githubUsername, branchName, baseBranchSha);
+    await createBranch(headers, githubUsername, UPSTREAM_REPO_NAME, branchName, baseBranchSha);
 
     // Create both files in a single commit with DCO sign-off
     await createFilesInSingleCommit(
       headers,
       githubUsername,
+      UPSTREAM_REPO_NAME,
       [
         { path: newYamlFilePath, content: yamlString },
         { path: newAttributionFilePath, content: attributionContent }
@@ -88,172 +86,6 @@ Creator names: ${attributionData.creator_names}
     console.error('Failed to create pull request:', error);
     return NextResponse.json({ error: 'Failed to create pull request' }, { status: 500 });
   }
-}
-
-async function getGitHubUsername(headers: HeadersInit): Promise<string> {
-  const response = await fetch(`${GITHUB_API_URL}/user`, {
-    headers
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error('Failed to fetch GitHub username:', response.status, errorText);
-    throw new Error('Failed to fetch GitHub username');
-  }
-
-  const data = await response.json();
-  return data.login;
-}
-
-async function checkUserForkExists(headers: HeadersInit, username: string) {
-  const response = await fetch(`${GITHUB_API_URL}/repos/${username}/${UPSTREAM_REPO_NAME}`, {
-    headers
-  });
-
-  return response.ok;
-}
-
-async function createFork(headers: HeadersInit) {
-  const response = await fetch(`${GITHUB_API_URL}/repos/${UPSTREAM_REPO_OWNER}/${UPSTREAM_REPO_NAME}/forks`, {
-    method: 'POST',
-    headers
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error('Failed to create fork:', response.status, errorText);
-    throw new Error('Failed to create fork');
-  }
-
-  const responseData = await response.json();
-  console.log('Fork created successfully:', responseData);
-}
-
-async function getBaseBranchSha(headers: HeadersInit, username: string) {
-  const response = await fetch(`${GITHUB_API_URL}/repos/${username}/${UPSTREAM_REPO_NAME}/git/refs/heads/${BASE_BRANCH}`, {
-    headers
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error('Failed to get base branch SHA:', response.status, errorText);
-    throw new Error('Failed to get base branch SHA');
-  }
-
-  const data = await response.json();
-  return data.object.sha;
-}
-
-async function createBranch(headers: HeadersInit, username: string, branchName: string, baseSha: string) {
-  const body = JSON.stringify({
-    ref: `refs/heads/${branchName}`,
-    sha: baseSha
-  });
-
-  console.log(`Creating branch with body: ${body}`);
-
-  const response = await fetch(`${GITHUB_API_URL}/repos/${username}/${UPSTREAM_REPO_NAME}/git/refs`, {
-    method: 'POST',
-    headers,
-    body
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error('Failed to create branch:', response.status, errorText);
-    throw new Error('Failed to create branch');
-  }
-
-  const responseData = await response.json();
-  console.log('Branch created successfully:', responseData);
-}
-
-async function createFilesInSingleCommit(
-  headers: HeadersInit,
-  username: string,
-  files: { path: string; content: string }[],
-  branchName: string,
-  commitMessage: string
-) {
-  const fileData = files.map((file) => ({
-    path: file.path,
-    mode: '100644',
-    type: 'blob',
-    content: file.content
-  }));
-
-  const response = await fetch(`${GITHUB_API_URL}/repos/${username}/${UPSTREAM_REPO_NAME}/git/trees`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({
-      base_tree: await getBaseTreeSha(headers, username, branchName),
-      tree: fileData
-    })
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error('Failed to create files:', response.status, errorText);
-    throw new Error('Failed to create files');
-  }
-
-  const treeData = await response.json();
-
-  const commitResponse = await fetch(`${GITHUB_API_URL}/repos/${username}/${UPSTREAM_REPO_NAME}/git/commits`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({
-      message: commitMessage,
-      tree: treeData.sha,
-      parents: [await getCommitSha(headers, username, branchName)]
-    })
-  });
-
-  if (!commitResponse.ok) {
-    const errorText = await commitResponse.text();
-    console.error('Failed to create commit:', commitResponse.status, errorText);
-    throw new Error('Failed to create commit');
-  }
-
-  const commitData = await commitResponse.json();
-
-  await fetch(`${GITHUB_API_URL}/repos/${username}/${UPSTREAM_REPO_NAME}/git/refs/heads/${branchName}`, {
-    method: 'PATCH',
-    headers,
-    body: JSON.stringify({
-      sha: commitData.sha
-    })
-  });
-}
-
-async function getBaseTreeSha(headers: HeadersInit, username: string, branchName: string): Promise<string> {
-  const response = await fetch(`${GITHUB_API_URL}/repos/${username}/${UPSTREAM_REPO_NAME}/git/trees/${branchName}`, {
-    headers
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error('Failed to get base tree SHA:', response.status, errorText);
-    throw new Error('Failed to get base tree SHA');
-  }
-
-  const data = await response.json();
-  return data.sha;
-}
-
-async function getCommitSha(headers: HeadersInit, username: string, branchName: string): Promise<string> {
-  const response = await fetch(`${GITHUB_API_URL}/repos/${username}/${UPSTREAM_REPO_NAME}/git/refs/heads/${branchName}`, {
-    headers
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error('Failed to get commit SHA:', response.status, errorText);
-    throw new Error('Failed to get commit SHA');
-  }
-
-  const data = await response.json();
-  return data.object.sha;
 }
 
 async function createPullRequest(headers: HeadersInit, username: string, branchName: string, knowledgeSummary: string, documentOutline: string) {

--- a/src/app/api/pr/skill/route.ts
+++ b/src/app/api/pr/skill/route.ts
@@ -4,13 +4,13 @@ import { getToken } from 'next-auth/jwt';
 import { NextRequest } from 'next/server';
 import yaml from 'js-yaml';
 import { SkillYamlData, AttributionData } from '@/types';
+import { GITHUB_API_URL, BASE_BRANCH } from '@/types/const';
 import { dumpYaml } from '@/utils/yamlConfig';
+import { checkUserForkExists, createBranch, createFilesInSingleCommit, createFork, getBaseBranchSha, getGitHubUsername } from '@/utils/github';
 
-const GITHUB_API_URL = 'https://api.github.com';
 const SKILLS_DIR = 'compositional_skills';
 const UPSTREAM_REPO_OWNER = process.env.NEXT_PUBLIC_TAXONOMY_REPO_OWNER!;
 const UPSTREAM_REPO_NAME = process.env.NEXT_PUBLIC_TAXONOMY_REPO!;
-const BASE_BRANCH = 'main';
 
 export async function POST(req: NextRequest) {
   const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET! });
@@ -37,9 +37,9 @@ export async function POST(req: NextRequest) {
     console.log('GitHub Username:', githubUsername);
 
     // Check if user's fork exists, if not, create it
-    const forkExists = await checkUserForkExists(headers, githubUsername);
+    const forkExists = await checkUserForkExists(headers, githubUsername, UPSTREAM_REPO_NAME);
     if (!forkExists) {
-      await createFork(headers);
+      await createFork(headers, UPSTREAM_REPO_OWNER, UPSTREAM_REPO_NAME, githubUsername);
     }
 
     const branchName = `skill-contribution-${Date.now()}`;
@@ -57,16 +57,18 @@ Creator names: ${attributionData.creator_names}
 `;
 
     // Get the base branch SHA
-    const baseBranchSha = await getBaseBranchSha(headers, githubUsername);
+    const baseBranchSha = await getBaseBranchSha(headers, githubUsername, UPSTREAM_REPO_NAME);
+
     console.log(`Base branch SHA: ${baseBranchSha}`);
 
     // Create a new branch in the user's fork
-    await createBranch(headers, githubUsername, branchName, baseBranchSha);
+    await createBranch(headers, githubUsername, UPSTREAM_REPO_NAME, branchName, baseBranchSha);
 
     // Create both files in a single commit
     await createFilesInSingleCommit(
       headers,
       githubUsername,
+      UPSTREAM_REPO_NAME,
       [
         { path: newYamlFilePath, content: yamlString },
         { path: newAttributionFilePath, content: attributionString }
@@ -83,172 +85,6 @@ Creator names: ${attributionData.creator_names}
     console.error('Failed to create pull request:', error);
     return NextResponse.json({ error: 'Failed to create pull request' }, { status: 500 });
   }
-}
-
-async function getGitHubUsername(headers: HeadersInit): Promise<string> {
-  const response = await fetch(`${GITHUB_API_URL}/user`, {
-    headers
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error('Failed to fetch GitHub username:', response.status, errorText);
-    throw new Error('Failed to fetch GitHub username');
-  }
-
-  const data = await response.json();
-  return data.login;
-}
-
-async function checkUserForkExists(headers: HeadersInit, username: string) {
-  const response = await fetch(`${GITHUB_API_URL}/repos/${username}/${UPSTREAM_REPO_NAME}`, {
-    headers
-  });
-
-  return response.ok;
-}
-
-async function createFork(headers: HeadersInit) {
-  const response = await fetch(`${GITHUB_API_URL}/repos/${UPSTREAM_REPO_OWNER}/${UPSTREAM_REPO_NAME}/forks`, {
-    method: 'POST',
-    headers
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error('Failed to create fork:', response.status, errorText);
-    throw new Error('Failed to create fork');
-  }
-
-  const responseData = await response.json();
-  console.log('Fork created successfully:', responseData);
-}
-
-async function getBaseBranchSha(headers: HeadersInit, username: string) {
-  const response = await fetch(`${GITHUB_API_URL}/repos/${username}/${UPSTREAM_REPO_NAME}/git/refs/heads/${BASE_BRANCH}`, {
-    headers
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error('Failed to get base branch SHA:', response.status, errorText);
-    throw new Error('Failed to get base branch SHA');
-  }
-
-  const data = await response.json();
-  return data.object.sha;
-}
-
-async function createBranch(headers: HeadersInit, username: string, branchName: string, baseSha: string) {
-  const body = JSON.stringify({
-    ref: `refs/heads/${branchName}`,
-    sha: baseSha
-  });
-
-  console.log(`Creating branch with body: ${body}`);
-
-  const response = await fetch(`${GITHUB_API_URL}/repos/${username}/${UPSTREAM_REPO_NAME}/git/refs`, {
-    method: 'POST',
-    headers,
-    body
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error('Failed to create branch:', response.status, errorText);
-    throw new Error('Failed to create branch');
-  }
-
-  const responseData = await response.json();
-  console.log('Branch created successfully:', responseData);
-}
-
-async function createFilesInSingleCommit(
-  headers: HeadersInit,
-  username: string,
-  files: { path: string; content: string }[],
-  branchName: string,
-  commitMessage: string
-) {
-  const fileData = files.map((file) => ({
-    path: file.path,
-    mode: '100644',
-    type: 'blob',
-    content: file.content
-  }));
-
-  const response = await fetch(`${GITHUB_API_URL}/repos/${username}/${UPSTREAM_REPO_NAME}/git/trees`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({
-      base_tree: await getBaseTreeSha(headers, username, branchName),
-      tree: fileData
-    })
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error('Failed to create files:', response.status, errorText);
-    throw new Error('Failed to create files');
-  }
-
-  const treeData = await response.json();
-
-  const commitResponse = await fetch(`${GITHUB_API_URL}/repos/${username}/${UPSTREAM_REPO_NAME}/git/commits`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({
-      message: commitMessage,
-      tree: treeData.sha,
-      parents: [await getCommitSha(headers, username, branchName)]
-    })
-  });
-
-  if (!commitResponse.ok) {
-    const errorText = await commitResponse.text();
-    console.error('Failed to create commit:', commitResponse.status, errorText);
-    throw new Error('Failed to create commit');
-  }
-
-  const commitData = await commitResponse.json();
-
-  await fetch(`${GITHUB_API_URL}/repos/${username}/${UPSTREAM_REPO_NAME}/git/refs/heads/${branchName}`, {
-    method: 'PATCH',
-    headers,
-    body: JSON.stringify({
-      sha: commitData.sha
-    })
-  });
-}
-
-async function getBaseTreeSha(headers: HeadersInit, username: string, branchName: string): Promise<string> {
-  const response = await fetch(`${GITHUB_API_URL}/repos/${username}/${UPSTREAM_REPO_NAME}/git/trees/${branchName}`, {
-    headers
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error('Failed to get base tree SHA:', response.status, errorText);
-    throw new Error('Failed to get base tree SHA');
-  }
-
-  const data = await response.json();
-  return data.sha;
-}
-
-async function getCommitSha(headers: HeadersInit, username: string, branchName: string): Promise<string> {
-  const response = await fetch(`${GITHUB_API_URL}/repos/${username}/${UPSTREAM_REPO_NAME}/git/refs/heads/${branchName}`, {
-    headers
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error('Failed to get commit SHA:', response.status, errorText);
-    throw new Error('Failed to get commit SHA');
-  }
-
-  const data = await response.json();
-  return data.object.sha;
 }
 
 async function createPullRequest(headers: HeadersInit, username: string, branchName: string, skillSummary: string, skillDescription: string) {

--- a/src/app/edit-submission/knowledge/[id]/page.tsx
+++ b/src/app/edit-submission/knowledge/[id]/page.tsx
@@ -4,7 +4,8 @@
 import * as React from 'react';
 import { useSession } from 'next-auth/react';
 import { AppLayout } from '../../../../components/AppLayout';
-import { AttributionData, PullRequestFile, KnowledgeYamlData, KnowledgeSchemaVersion } from '@/types';
+import { AttributionData, PullRequestFile, KnowledgeYamlData } from '@/types';
+import { KnowledgeSchemaVersion } from '@/types/const';
 import { fetchPullRequest, fetchFileContent, fetchPullRequestFiles } from '../../../../utils/github';
 import yaml from 'js-yaml';
 import axios from 'axios';

--- a/src/app/edit-submission/skill/[id]/page.tsx
+++ b/src/app/edit-submission/skill/[id]/page.tsx
@@ -4,7 +4,8 @@
 import * as React from 'react';
 import { useSession } from 'next-auth/react';
 import { AppLayout } from '../../../../components/AppLayout';
-import { AttributionData, PullRequestFile, SkillYamlData, SkillSchemaVersion } from '@/types';
+import { AttributionData, PullRequestFile, SkillYamlData } from '@/types';
+import { SkillSchemaVersion } from '@/types/const';
 import { fetchPullRequest, fetchFileContent, fetchPullRequestFiles } from '../../../../utils/github';
 import yaml from 'js-yaml';
 import axios from 'axios';

--- a/src/components/Contribute/Knowledge/DownloadYaml/DownloadYaml.tsx
+++ b/src/components/Contribute/Knowledge/DownloadYaml/DownloadYaml.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { validateFields } from '../validation';
 import { ActionGroupAlertContent, KnowledgeFormData } from '..';
-import { KnowledgeYamlData, KnowledgeSchemaVersion } from '@/types';
+import { KnowledgeYamlData } from '@/types';
+import { KnowledgeSchemaVersion } from '@/types/const';
 import { dumpYaml } from '@/utils/yamlConfig';
 import { DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown/DropdownItem';
 import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';

--- a/src/components/Contribute/Knowledge/Submit/Submit.tsx
+++ b/src/components/Contribute/Knowledge/Submit/Submit.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
 import { ActionGroupAlertContent, KnowledgeFormData } from '..';
-import { AttributionData, KnowledgeYamlData, KnowledgeSchemaVersion } from '@/types';
+import { AttributionData, KnowledgeYamlData } from '@/types';
+import { KnowledgeSchemaVersion } from '@/types/const';
 import { dumpYaml } from '@/utils/yamlConfig';
 import { validateFields } from '../validation';
 
@@ -52,6 +53,15 @@ const Submit: React.FC<Props> = ({ disableAction, knowledgeFormData, setActionGr
       license_of_the_work: knowledgeFormData.licenseWork!,
       creator_names: knowledgeFormData.creators!
     };
+
+    const waitForSubmissionAlert: ActionGroupAlertContent = {
+      title: 'Knowledge contribution submission in progress.!',
+      message: `Once the submission is successful, it will provide the link to the newly created Pull Request.`,
+      success: true,
+      waitAlert: true,
+      timeout: false
+    };
+    setActionGroupAlertContent(waitForSubmissionAlert);
 
     const name = knowledgeFormData.name;
     const email = knowledgeFormData.email;

--- a/src/components/Contribute/Knowledge/Update/Update.tsx
+++ b/src/components/Contribute/Knowledge/Update/Update.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
 import { ActionGroupAlertContent, KnowledgeFormData } from '..';
-import { AttributionData, KnowledgeYamlData, PullRequestFile, KnowledgeSchemaVersion } from '@/types';
+import { AttributionData, KnowledgeYamlData, PullRequestFile } from '@/types';
+import { KnowledgeSchemaVersion } from '@/types/const';
 import { dumpYaml } from '@/utils/yamlConfig';
 import { validateFields } from '../validation';
 import { amendCommit, getGitHubUsername, updatePullRequest } from '@/utils/github';
@@ -42,7 +43,14 @@ const Update: React.FC<Props> = ({
           body: knowledgeFormData.documentOutline
         });
 
-        const githubUsername = await getGitHubUsername(session.accessToken);
+        const headers = {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session.accessToken}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28'
+        };
+
+        const githubUsername = await getGitHubUsername(headers);
         console.log(`GitHub username: ${githubUsername}`);
 
         const knowledgeYamlData: KnowledgeYamlData = {
@@ -101,6 +109,15 @@ Creator names: ${attributionData.creator_names}
           yaml: finalYamlPath,
           attribution: finalAttributionPath
         };
+
+        const waitForSubmissionAlert: ActionGroupAlertContent = {
+          title: 'Knowledge contribution update is in progress.!',
+          message: `Once the update is successful, it will provide the link to the updated Pull Request.`,
+          success: true,
+          waitAlert: true,
+          timeout: false
+        };
+        setActionGroupAlertContent(waitForSubmissionAlert);
 
         const res = await fetch('/api/envConfig');
         const envConfig = await res.json();

--- a/src/components/Contribute/Knowledge/ViewDropdown/ViewDropdown.tsx
+++ b/src/components/Contribute/Knowledge/ViewDropdown/ViewDropdown.tsx
@@ -6,7 +6,8 @@ import { MenuToggle, MenuToggleElement } from '@patternfly/react-core/dist/dynam
 import { KnowledgeFormData } from '..';
 import YamlCodeModal from '@/components/YamlCodeModal';
 import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
-import { AttributionData, KnowledgeYamlData, KnowledgeSchemaVersion } from '@/types';
+import { AttributionData, KnowledgeYamlData } from '@/types';
+import { KnowledgeSchemaVersion } from '@/types/const';
 import { dumpYaml } from '@/utils/yamlConfig';
 import FileIcon from '@patternfly/react-icons/dist/dynamic/icons/file-icon';
 import EyeIcon from '@patternfly/react-icons/dist/esm/icons/eye-icon';

--- a/src/components/Contribute/Knowledge/index.tsx
+++ b/src/components/Contribute/Knowledge/index.tsx
@@ -30,6 +30,7 @@ import Update from './Update/Update';
 import { PullRequestFile } from '@/types';
 import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
 import { useRouter } from 'next/navigation';
+import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
 
 export interface QuestionAndAnswerPair {
   immutable: boolean;
@@ -81,8 +82,10 @@ export interface KnowledgeEditFormData {
 export interface ActionGroupAlertContent {
   title: string;
   message: string;
+  waitAlert?: boolean;
   url?: string;
   success: boolean;
+  timeout?: number | boolean;
 }
 
 export interface KnowledgeFormProps {
@@ -166,7 +169,14 @@ export const KnowledgeForm: React.FunctionComponent<KnowledgeFormProps> = ({ kno
     const fetchUsername = async () => {
       if (session?.accessToken) {
         try {
-          const fetchedUsername = await getGitHubUsername(session.accessToken);
+          const headers = {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${session.accessToken}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28'
+          };
+
+          const fetchedUsername = await getGitHubUsername(headers);
           setGithubUsername(fetchedUsername);
         } catch (error) {
           console.error('Failed to fetch GitHub username:', error);
@@ -471,20 +481,24 @@ export const KnowledgeForm: React.FunctionComponent<KnowledgeFormProps> = ({ kno
 
           {actionGroupAlertContent && (
             <Alert
-              variant={actionGroupAlertContent.success ? 'success' : 'danger'}
+              variant={actionGroupAlertContent.waitAlert ? 'info' : actionGroupAlertContent.success ? 'success' : 'danger'}
               title={actionGroupAlertContent.title}
-              timeout={10000}
+              timeout={actionGroupAlertContent.timeout == false ? false : actionGroupAlertContent.timeout}
               onTimeout={onCloseActionGroupAlert}
               actionClose={<AlertActionCloseButton onClose={onCloseActionGroupAlert} />}
             >
               <p>
+                {actionGroupAlertContent.waitAlert && <Spinner size="md" />}
                 {actionGroupAlertContent.message}
                 <br />
-                {actionGroupAlertContent.success && actionGroupAlertContent.url && actionGroupAlertContent.url.trim().length > 0 && (
-                  <a href={actionGroupAlertContent.url} target="_blank" rel="noreferrer">
-                    View your pull request
-                  </a>
-                )}
+                {!actionGroupAlertContent.waitAlert &&
+                  actionGroupAlertContent.success &&
+                  actionGroupAlertContent.url &&
+                  actionGroupAlertContent.url.trim().length > 0 && (
+                    <a href={actionGroupAlertContent.url} target="_blank" rel="noreferrer">
+                      View your pull request
+                    </a>
+                  )}
               </p>
             </Alert>
           )}

--- a/src/components/Contribute/Knowledge/validation.tsx
+++ b/src/components/Contribute/Knowledge/validation.tsx
@@ -152,12 +152,6 @@ export const validateFields = (
     return false;
   }
 
-  const actionGroupAlertContent: ActionGroupAlertContent = {
-    title: `Data entry success`,
-    message: `All fields completed successfully`,
-    success: true
-  };
-  setActionGroupAlertContent(actionGroupAlertContent);
   return true;
 };
 

--- a/src/components/Contribute/Skill/DownloadYaml/DownloadYaml.tsx
+++ b/src/components/Contribute/Skill/DownloadYaml/DownloadYaml.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { validateFields } from '../validation';
 import { ActionGroupAlertContent, SkillFormData } from '..';
-import { SkillYamlData, SkillSchemaVersion } from '@/types';
+import { SkillYamlData } from '@/types';
 import { dumpYaml } from '@/utils/yamlConfig';
 import { DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown/DropdownItem';
 import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
+import { SkillSchemaVersion } from '@/types/const';
 
 interface Props {
   disableAction: boolean;

--- a/src/components/Contribute/Skill/Submit/Submit.tsx
+++ b/src/components/Contribute/Skill/Submit/Submit.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
 import { ActionGroupAlertContent, SkillFormData } from '..';
-import { AttributionData, SkillYamlData, SkillSchemaVersion } from '@/types';
+import { AttributionData, SkillYamlData } from '@/types';
+import { SkillSchemaVersion } from '@/types/const';
 import { dumpYaml } from '@/utils/yamlConfig';
 import { validateFields } from '../validation';
 
@@ -45,6 +46,15 @@ const Submit: React.FC<Props> = ({ disableAction, skillFormData, setActionGroupA
       link_to_work: '',
       revision: ''
     };
+
+    const waitForSubmissionAlert: ActionGroupAlertContent = {
+      title: 'Skill contribution submission in progress.!',
+      message: `Once the submission is successful, it will provide the link to the newly created Pull Request.`,
+      success: true,
+      waitAlert: true,
+      timeout: false
+    };
+    setActionGroupAlertContent(waitForSubmissionAlert);
 
     const name = skillFormData.name;
     const email = skillFormData.email;

--- a/src/components/Contribute/Skill/Update/Update.tsx
+++ b/src/components/Contribute/Skill/Update/Update.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
 import { ActionGroupAlertContent, SkillFormData } from '..';
-import { AttributionData, SkillYamlData, PullRequestFile, SkillSchemaVersion } from '@/types';
+import { AttributionData, SkillYamlData, PullRequestFile } from '@/types';
+import { SkillSchemaVersion } from '@/types/const';
 import { dumpYaml } from '@/utils/yamlConfig';
 import { validateFields } from '../validation';
 import { amendCommit, getGitHubUsername, updatePullRequest } from '@/utils/github';
@@ -42,7 +43,13 @@ const Update: React.FC<Props> = ({
           body: skillFormData.documentOutline
         });
 
-        const githubUsername = await getGitHubUsername(session.accessToken);
+        const headers = {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session.accessToken}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28'
+        };
+        const githubUsername = await getGitHubUsername(headers);
         console.log(`GitHub username: ${githubUsername}`);
 
         const skillYamlData: SkillYamlData = {
@@ -93,6 +100,15 @@ Creator names: ${attributionData.creator_names}
 
         const res = await fetch('/api/envConfig');
         const envConfig = await res.json();
+
+        const waitForSubmissionAlert: ActionGroupAlertContent = {
+          title: 'Skill contribution update is in progress.!',
+          message: `Once the update is successful, it will provide the link to the updated Pull Request.`,
+          success: true,
+          waitAlert: true,
+          timeout: false
+        };
+        setActionGroupAlertContent(waitForSubmissionAlert);
 
         const amendedCommitResponse = await amendCommit(
           session.accessToken,

--- a/src/components/Contribute/Skill/ViewDropdown/ViewDropdown.tsx
+++ b/src/components/Contribute/Skill/ViewDropdown/ViewDropdown.tsx
@@ -6,7 +6,8 @@ import { MenuToggle, MenuToggleElement } from '@patternfly/react-core/dist/dynam
 import { SkillFormData } from '..';
 import YamlCodeModal from '@/components/YamlCodeModal';
 import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
-import { AttributionData, SkillSchemaVersion, SkillYamlData } from '@/types';
+import { AttributionData, SkillYamlData } from '@/types';
+import { SkillSchemaVersion } from '@/types/const';
 import { dumpYaml } from '@/utils/yamlConfig';
 import FileIcon from '@patternfly/react-icons/dist/dynamic/icons/file-icon';
 import EyeIcon from '@patternfly/react-icons/dist/esm/icons/eye-icon';

--- a/src/components/Contribute/Skill/validation.tsx
+++ b/src/components/Contribute/Skill/validation.tsx
@@ -80,13 +80,6 @@ export const validateFields = (
     setActionGroupAlertContent(actionGroupAlertContent);
     return false;
   }
-
-  const actionGroupAlertContent: ActionGroupAlertContent = {
-    title: `Data entry success`,
-    message: `All fields completed successfully`,
-    success: true
-  };
-  setActionGroupAlertContent(actionGroupAlertContent);
   return true;
 };
 

--- a/src/components/Dashboard/index.tsx
+++ b/src/components/Dashboard/index.tsx
@@ -21,7 +21,11 @@ const Index: React.FunctionComponent = () => {
   const fetchAndSetPullRequests = React.useCallback(async () => {
     if (session?.accessToken) {
       try {
-        const fetchedUsername = await getGitHubUsername(session.accessToken);
+        const header = {
+          Authorization: `Bearer ${session.accessToken}`,
+          Accept: 'application/vnd.github.v3+json'
+        };
+        const fetchedUsername = await getGitHubUsername(header);
         setUsername(fetchedUsername);
         const data = await fetchPullRequests(session.accessToken);
         const filteredPRs = data.filter(

--- a/src/types/const.ts
+++ b/src/types/const.ts
@@ -1,0 +1,8 @@
+// src/types/const.ts
+// https://github.com/instructlab/schema/blob/main/src/instructlab/schema/
+export const KnowledgeSchemaVersion = 3;
+export const SkillSchemaVersion = 3;
+export const FORK_CLONE_CHECK_RETRY_TIMEOUT = 5000;
+export const FORK_CLONE_CHECK_RETRY_COUNT = 10;
+export const GITHUB_API_URL = 'https://api.github.com';
+export const BASE_BRANCH = 'main';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,9 +1,3 @@
-// src/types/index.ts
-
-// https://github.com/instructlab/schema/blob/main/src/instructlab/schema/
-export const KnowledgeSchemaVersion = 3;
-export const SkillSchemaVersion = 3;
-
 export interface Endpoint {
   id: string;
   url: string;


### PR DESCRIPTION
taxonomy clone is not present in user github account.

UI attempts to create the clone, but the clone can take some time to finish. When UI attempts to get the base sha of the repo's main branch it fails because the repository is empty.

Add retry logic to check the bash sha every 5 seconds and make 10 attempts. If clone takes more than 50 seconds it fails.

In this specific scenario, when user creates it's first contribution, it can take a bit longer because of the repo cloning. Without any notification, this wait time might look like a no-op to the user. To address this added a spinner with an alter message that notifies user that the submission is in progress.

Patch also includes refactoring of duplicate code present across api/skill and api/knowledge.

Fixes #52 