### PR TITLE
Fix ilab link in empty state dashboard

### DIFF
--- a/src/components/Dashboard/index.tsx
+++ b/src/components/Dashboard/index.tsx
@@ -145,7 +145,7 @@ const Index: React.FunctionComponent = () => {
                   icon={<GithubIcon />}
                   iconPosition="right"
                   component="a"
-                  href="https://github.com/your-repo"
+                  href="https://github.com/instructlab"
                   target="_blank"
                   rel="noopener noreferrer"
                 >


### PR DESCRIPTION
I didn't change this from the patternfly example 🤦 