### PR TITLE
22: Add configuration options for introducing dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,67 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "production"
+    target-branch: "main"
+    labels:
+      - "npm dependencies"
+      - "frontend"
+    open-pull-requests-limit: 3
+    groups:
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
+          - typescript-eslint
+        update-types:
+          - "minor"
+          - "patch"
+      react:
+        patterns:
+          - react
+          - react-dom
+        update-types:
+          - "minor"
+          - "patch"
+      patternfly:
+        patterns:
+          - "@patternfly/*"
+          - patternfly
+        update-types:
+          - "minor"
+          - "patch"
+      typescript-libraries:
+        patterns:
+          - "@types/*"
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    labels:
+      - "github-actions"
+    open-pull-requests-limit: 3
+    groups:
+      actions-deps:
+        patterns:
+          - "*"
+  - package-ecosystem: "gomod"
+    directory: "/pathservice"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    labels:
+      - "go dependencies"
+    open-pull-requests-limit: 3
+  - package-ecosystem: "docker"
+    directory: "/server"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "docker dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "instructlab/ui-maintainers"
     allow:
       - dependency-type: "production"
     target-branch: "main"
     labels:
       - "npm dependencies"
       - "frontend"
-    open-pull-requests-limit: 3
     groups:
       typescript-eslint:
         patterns:
@@ -43,10 +44,11 @@ updates:
     directory: "/.github/workflows"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "instructlab/ui-maintainers"
     target-branch: "main"
     labels:
       - "github-actions"
-    open-pull-requests-limit: 3
     groups:
       actions-deps:
         patterns:
@@ -55,13 +57,16 @@ updates:
     directory: "/pathservice"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "instructlab/ui-maintainers"
     target-branch: "main"
     labels:
       - "go dependencies"
-    open-pull-requests-limit: 3
   - package-ecosystem: "docker"
     directory: "/server"
     schedule:
       interval: "monthly"
+    reviewers:
+      - "instructlab/ui-maintainers"
     labels:
       - "docker dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,3 +70,4 @@ updates:
       - "instructlab/ui-maintainers"
     labels:
       - "docker dependencies"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,7 +63,7 @@ updates:
     labels:
       - "go dependencies"
   - package-ecosystem: "docker"
-    directory: "/server"
+    directory: "/"
     schedule:
       interval: "monthly"
     reviewers:


### PR DESCRIPTION
fixes https://github.com/instructlab/ui/issues/22

Enabling dependabot for the repository. The configuration aims at addressing Docker images, npm packages, and go modules.

Summary of changes:

- Used Grouping: Dependabot will group certain dependencies with the keyword “group”.
- For `github-actions`, I just used a single group, and used a wildcard pattern to achieve like an "everything group".
- Limiting the security updates to the dependencies and ignore dev dependencies. Highlighted in `dependency-type: "production"` 