### PR TITLE
153: Attribute information improvements

### DIFF
--- a/src/components/Contribute/Knowledge/AttributionInformation/AttributionInformation.tsx
+++ b/src/components/Contribute/Knowledge/AttributionInformation/AttributionInformation.tsx
@@ -146,7 +146,7 @@ const AttributionInformation: React.FC<Props> = ({
       }
     >
       <FormGroup isRequired key={'attribution-info-details-id'}>
-      <TextInput
+        <TextInput
           isRequired
           type="url"
           aria-label="link_work"

--- a/src/components/Contribute/Knowledge/AttributionInformation/AttributionInformation.tsx
+++ b/src/components/Contribute/Knowledge/AttributionInformation/AttributionInformation.tsx
@@ -146,27 +146,7 @@ const AttributionInformation: React.FC<Props> = ({
       }
     >
       <FormGroup isRequired key={'attribution-info-details-id'}>
-        <TextInput
-          isRequired
-          type="text"
-          aria-label="title_work"
-          placeholder="Enter title of work"
-          validated={validTitle}
-          value={titleWork}
-          onChange={(_event, value) => setTitleWork(value)}
-          onBlur={() => validateTitle(titleWork)}
-        />
-        {validTitle === ValidatedOptions.error && (
-          <FormHelperText>
-            <HelperText>
-              <HelperTextItem icon={<ExclamationCircleIcon />} variant={validTitle}>
-                Title is required.
-              </HelperTextItem>
-            </HelperText>
-          </FormHelperText>
-        )}
-
-        <TextInput
+      <TextInput
           isRequired
           type="url"
           aria-label="link_work"
@@ -190,6 +170,25 @@ const AttributionInformation: React.FC<Props> = ({
             <HelperText>
               <HelperTextItem icon={<ExclamationCircleIcon />} variant={validLink}>
                 Please enter a valid URL.
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        )}
+        <TextInput
+          isRequired
+          type="text"
+          aria-label="title_work"
+          placeholder="Enter title of work"
+          validated={validTitle}
+          value={titleWork}
+          onChange={(_event, value) => setTitleWork(value)}
+          onBlur={() => validateTitle(titleWork)}
+        />
+        {validTitle === ValidatedOptions.error && (
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem icon={<ExclamationCircleIcon />} variant={validTitle}>
+                Title is required.
               </HelperTextItem>
             </HelperText>
           </FormHelperText>


### PR DESCRIPTION
## Why

Existing implementation: The existing form places the URL after the name requiring user to manually enter all fields

UX recommendations
- Place URL as the first field

## What:
- Update AttributionInformation.tsx file to place the URL text input as the first field within the attribution form section. 

## Reference
- [IL Issue](https://github.com/instructlab/ui/issues/153)

## How to test:

## Screenshots
### Before
![Screenshot 2024-09-20 131412](https://github.com/user-attachments/assets/d254730e-0711-4b6a-a533-688f4e479d8d)

### After
![Screenshot 2024-09-20 131503](https://github.com/user-attachments/assets/665295e7-e550-4345-86bd-9609c17a31ec)
