### PR TITLE
Change limit from 750 char to words

### DIFF
--- a/src/components/Contribute/Knowledge/FilePathInformation/FilePathInformation.tsx
+++ b/src/components/Contribute/Knowledge/FilePathInformation/FilePathInformation.tsx
@@ -23,7 +23,7 @@ const FilePathInformation: React.FC<Props> = ({ reset, path, setFilePath }) => {
             ),
             id: 'file-path-info-id'
           }}
-          titleDescription="Specify the file path for the QnA and Attribution files."
+          titleDescription="Specify the file path for the QnA and Attribution files. Once path is selected, please add your leaf directory name for your contribution."
         />
       }
     >

--- a/src/components/Contribute/Knowledge/KnowledgeQuestionAnswerPairs/KnowledgeQuestionAnswerPairs.tsx
+++ b/src/components/Contribute/Knowledge/KnowledgeQuestionAnswerPairs/KnowledgeQuestionAnswerPairs.tsx
@@ -35,8 +35,7 @@ const KnowledgeQuestionAnswerPairs: React.FC<Props> = ({
         isRequired
         type="text"
         aria-label={`Context ${seedExampleIndex + 1}`}
-        placeholder="Enter the context from which the Q&A pairs are derived. (500 character max)"
-        maxLength={500}
+        placeholder="Enter the context from which the Q&A pairs are derived. (500 words max)"
         value={seedExample.context}
         validated={seedExample.isContextValid}
         onChange={(_event, contextValue: string) => handleContextInputChange(seedExampleIndex, contextValue)}
@@ -46,7 +45,7 @@ const KnowledgeQuestionAnswerPairs: React.FC<Props> = ({
         <FormHelperText key={seedExampleIndex * 10 + 2}>
           <HelperText>
             <HelperTextItem icon={<ExclamationCircleIcon />} variant={seedExample.isContextValid}>
-              {seedExample.validationError || 'Context is required. It must be non empty and less than 500 characters.'}
+              {seedExample.validationError ? seedExample.validationError : 'Context is required. It must be non empty and less than 500 words.'}
             </HelperTextItem>
           </HelperText>
         </FormHelperText>
@@ -87,7 +86,7 @@ const KnowledgeQuestionAnswerPairs: React.FC<Props> = ({
                 <HelperText>
                   <HelperTextItem icon={<ExclamationCircleIcon />} variant={seedExample.questionAndAnswers[questionAnswerIndex].isQuestionValid}>
                     {seedExample.questionAndAnswers[questionAnswerIndex].questionValidationError ||
-                      'Question is required. Total length of all Q&A pairs should be less than 250 characters.'}
+                      'Question is required. Total length of all Q&A pairs should be less than 250 words.'}
                   </HelperTextItem>
                 </HelperText>
               </FormHelperText>
@@ -108,7 +107,7 @@ const KnowledgeQuestionAnswerPairs: React.FC<Props> = ({
                 <HelperText>
                   <HelperTextItem icon={<ExclamationCircleIcon />} variant={seedExample.questionAndAnswers[questionAnswerIndex].isAnswerValid}>
                     {seedExample.questionAndAnswers[questionAnswerIndex].answerValidationError ||
-                      'Answer is required. Total length of all Q&A pairs should be less than 250 characters.'}
+                      'Answer is required. Total length of all Q&A pairs should be less than 250 words.'}
                   </HelperTextItem>
                 </HelperText>
               </FormHelperText>

--- a/src/components/Contribute/Knowledge/index.tsx
+++ b/src/components/Contribute/Knowledge/index.tsx
@@ -220,31 +220,65 @@ export const KnowledgeForm: React.FunctionComponent<KnowledgeFormProps> = ({ kno
     }
   }, [knowledgeEditFormData]);
 
-  const validateContext = (context: string): ValidatedOptions => {
-    if (context.length > 0 && context.length < 500) {
+  const validateContext = (seedExample: SeedExample): SeedExample => {
+    // Split the context into words based on spaces
+    const contextStr = seedExample.context.trim();
+    if (contextStr.length == 0) {
+      setDisableAction(true);
+      seedExample.validationError = 'Context is required';
+      seedExample.isContextValid = ValidatedOptions.error;
+      return seedExample;
+    }
+    const tokens = contextStr.split(/\s+/);
+    if (tokens.length > 0 && tokens.length <= 500) {
       setDisableAction(!checkKnowledgeFormCompletion(knowledgeFormData));
-      return ValidatedOptions.success;
+      seedExample.isContextValid = ValidatedOptions.success;
+      return seedExample;
     }
     setDisableAction(true);
-    return ValidatedOptions.error;
+    seedExample.validationError = 'Context must be less than 500 words. Current word count: ' + tokens.length;
+    seedExample.isContextValid = ValidatedOptions.error;
+    return seedExample;
   };
 
-  const validateQuestion = (question: string): ValidatedOptions => {
-    if (question.length > 0 && question.length < 250) {
+  const validateQuestion = (qnaPair: QuestionAndAnswerPair): QuestionAndAnswerPair => {
+    const questionStr = qnaPair.question.trim();
+    if (questionStr.length == 0) {
+      setDisableAction(true);
+      qnaPair.questionValidationError = 'Question is required';
+      qnaPair.isQuestionValid = ValidatedOptions.error;
+      return qnaPair;
+    }
+    const tokens = questionStr.split(/\s+/);
+    if (tokens.length > 0 && tokens.length < 250) {
       setDisableAction(!checkKnowledgeFormCompletion(knowledgeFormData));
-      return ValidatedOptions.success;
+      qnaPair.isQuestionValid = ValidatedOptions.success;
+      return qnaPair;
     }
     setDisableAction(true);
-    return ValidatedOptions.error;
+    qnaPair.questionValidationError = 'Question must be less than 250 words. Current word count: ' + tokens.length;
+    qnaPair.isQuestionValid = ValidatedOptions.error;
+    return qnaPair;
   };
 
-  const validateAnswer = (answer: string): ValidatedOptions => {
-    if (answer.length > 0 && answer.length < 250) {
+  const validateAnswer = (qnaPair: QuestionAndAnswerPair): QuestionAndAnswerPair => {
+    const answerStr = qnaPair.answer.trim();
+    if (answerStr.length == 0) {
+      setDisableAction(true);
+      qnaPair.answerValidationError = 'Answer is required';
+      qnaPair.isAnswerValid = ValidatedOptions.error;
+      return qnaPair;
+    }
+    const tokens = answerStr.split(/\s+/);
+    if (tokens.length > 0 && tokens.length < 250) {
       setDisableAction(!checkKnowledgeFormCompletion(knowledgeFormData));
-      return ValidatedOptions.success;
+      qnaPair.isAnswerValid = ValidatedOptions.success;
+      return qnaPair;
     }
     setDisableAction(true);
-    return ValidatedOptions.error;
+    qnaPair.answerValidationError = 'Answer must be less than 250 words. Current word count: ' + tokens.length;
+    qnaPair.isAnswerValid = ValidatedOptions.error;
+    return qnaPair;
   };
 
   const handleContextInputChange = (seedExampleIndex: number, contextValue: string): void => {
@@ -262,14 +296,12 @@ export const KnowledgeForm: React.FunctionComponent<KnowledgeFormProps> = ({ kno
 
   const handleContextBlur = (seedExampleIndex: number): void => {
     setSeedExamples(
-      seedExamples.map((seedExample: SeedExample, index: number) =>
-        index === seedExampleIndex
-          ? {
-              ...seedExample,
-              isContextValid: validateContext(seedExample.context)
-            }
-          : seedExample
-      )
+      seedExamples.map((seedExample: SeedExample, index: number) => {
+        if (index === seedExampleIndex) {
+          return validateContext(seedExample);
+        }
+        return seedExample;
+      })
     );
   };
 
@@ -299,14 +331,12 @@ export const KnowledgeForm: React.FunctionComponent<KnowledgeFormProps> = ({ kno
         index === seedExampleIndex
           ? {
               ...seedExample,
-              questionAndAnswers: seedExample.questionAndAnswers.map((questionAndAnswerPair: QuestionAndAnswerPair, index: number) =>
-                index === questionAndAnswerIndex
-                  ? {
-                      ...questionAndAnswerPair,
-                      isQuestionValid: validateQuestion(questionAndAnswerPair.question)
-                    }
-                  : questionAndAnswerPair
-              )
+              questionAndAnswers: seedExample.questionAndAnswers.map((questionAndAnswerPair: QuestionAndAnswerPair, index: number) => {
+                if (index === questionAndAnswerIndex) {
+                  return validateQuestion(questionAndAnswerPair);
+                }
+                return questionAndAnswerPair;
+              })
             }
           : seedExample
       )
@@ -339,14 +369,12 @@ export const KnowledgeForm: React.FunctionComponent<KnowledgeFormProps> = ({ kno
         index === seedExampleIndex
           ? {
               ...seedExample,
-              questionAndAnswers: seedExample.questionAndAnswers.map((questionAndAnswerPair: QuestionAndAnswerPair, index: number) =>
-                index === questionAndAnswerIndex
-                  ? {
-                      ...questionAndAnswerPair,
-                      isAnswerValid: validateAnswer(questionAndAnswerPair.answer)
-                    }
-                  : questionAndAnswerPair
-              )
+              questionAndAnswers: seedExample.questionAndAnswers.map((questionAndAnswerPair: QuestionAndAnswerPair, index: number) => {
+                if (index === questionAndAnswerIndex) {
+                  return validateAnswer(questionAndAnswerPair);
+                }
+                return questionAndAnswerPair;
+              })
             }
           : seedExample
       )

--- a/src/components/Contribute/Knowledge/validation.tsx
+++ b/src/components/Contribute/Knowledge/validation.tsx
@@ -34,13 +34,18 @@ const hasDuplicateQuestionAndAnswerPairs = (seedExample: SeedExample): { duplica
   return { duplicate: false, index: -1 };
 };
 
-// Validate that the total length of all the question and answer pairs in a seed example is not more than 250 characters
+// Validate that the total length of all the question and answer pairs
+// and context in a seed example is not more than 750 characters.
 const validateQuestionAndAnswerPairs = (seedExample: SeedExample): { success: boolean; currLength: number } => {
-  const totalLength = seedExample.questionAndAnswers.reduce((acc, questionAndAnswerPair) => {
-    return acc + questionAndAnswerPair.question.length + questionAndAnswerPair.answer.length;
+  const totalQnAPairsTokenCount = seedExample.questionAndAnswers.reduce((acc, questionAndAnswerPair) => {
+    const questionTokens = questionAndAnswerPair.question.trim().split(/\s+/);
+    const answerTokens = questionAndAnswerPair.answer.trim().split(/\s+/);
+    return acc + questionTokens.length + answerTokens.length;
   }, 0);
 
-  if (totalLength > 250) {
+  const contextTokens = seedExample.context.trim().split(/\s+/);
+  const totalLength = totalQnAPairsTokenCount + contextTokens.length;
+  if (totalLength > 750) {
     return { success: false, currLength: totalLength };
   }
   return { success: true, currLength: totalLength };
@@ -133,8 +138,8 @@ export const validateFields = (
     const { success, currLength: length } = validateQuestionAndAnswerPairs(knowledgeFormData.seedExamples[index]);
     if (!success) {
       const actionGroupAlertContent: ActionGroupAlertContent = {
-        title: `Seed example ${index} has an issue!`,
-        message: `Total size of the Q&A pairs should not exceed 250 characters (current size ${length}). Please provide shorter Q&A pairs.`,
+        title: `Seed Example ${index + 1} has an issue!`,
+        message: `Total size of the Q&A pairs and context should not exceed 750 words (current size ${length}). Please provide shorter Q&A pairs or context.`,
         success: false
       };
       setActionGroupAlertContent(actionGroupAlertContent);


### PR DESCRIPTION
After discussion with Taxonomy Traiger team, it was concluded that at this point of time, having a 750 max words limit is a better constraint compared to 750 char. 
Ideally this constraints should be enforced based on the number of tokens. Each model can have it's own way of splitting the string in the tokens, so determining number of tokens in any string depends on the model. Having a tokenizer service, that exposes a REST API to return the numbers of tokens in the provided string based on the base model, would be a really useful service in this scenario. We can leverage that to enforce the limits in terms of token. 