### PR TITLE
Adjust flex layout to avoid help and avatar stacking in masthead

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -21,7 +21,6 @@ import { PageSidebarBody } from '@patternfly/react-core/dist/dynamic/components/
 import { SkipToContent } from '@patternfly/react-core/dist/dynamic/components/SkipToContent';
 import { Spinner } from '@patternfly/react-core/dist/dynamic/components/Spinner';
 import { BarsIcon } from '@patternfly/react-icons/dist/dynamic/icons/bars-icon';
-import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex';
 import { TextContent, Text, TextVariants } from '@patternfly/react-core/dist/dynamic/components/Text';
 import { useTheme } from '../context/ThemeContext';
 import Link from 'next/link';
@@ -81,7 +80,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
           <BarsIcon />
         </Button>
       </MastheadToggle>
-      <MastheadMain>
+      <MastheadMain style={{ flexShrink: 1, display: 'flex', alignItems: 'center' }}>
         <MastheadBrand>
           <Brand src="/updated-logo.png" alt="InstructLab Logo" heights={{ default: '60px' }} />
         </MastheadBrand>
@@ -89,15 +88,9 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
           <Text component={TextVariants.h1}>InstructLab</Text>
         </TextContent>
       </MastheadMain>
-      <MastheadContent style={{ width: '100%' }}>
-        <Flex spaceItems={{ default: 'spaceItemsXl' }} style={{ paddingLeft: '80%', display: 'flex', alignItems: 'center' }}>
-          <FlexItem>
-            <HelpDropdown />
-          </FlexItem>
-          <FlexItem>
-            <UserMenu />
-          </FlexItem>
-        </Flex>
+      <MastheadContent style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', flexWrap: 'nowrap' }}>
+        <HelpDropdown />
+        <UserMenu />
       </MastheadContent>
     </Masthead>
   );


### PR DESCRIPTION
Before (L) After (R)

<img width="529" alt="image" src="https://github.com/user-attachments/assets/1f962f13-7478-4705-94bb-85eea97996aa">
