### PR TITLE
point back to upstream and add SS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,27 @@ report a bug, open an [issue](https://github.com/instructlab/ui/issues)! We'd lo
 For more, check out the [InstructLab UI Contribution Guide](CONTRIBUTING.md)
 and [InstructLab Community Guide](https://github.com/instructlab/community/blob/main/CONTRIBUTING.md).
 
+## Updating the Sealed Secrets
+
+To update the sealed secret, you must communicate with the controller that lives in the `kube-system` namespace of the qa cluster.
+After signing in to the cluster, you can re-writing the secret file that you want to seal. Then you simply `cat` the secret file,
+and pipe that to the `kubeseal` binary as follows:
+
+```bash
+cat <secret_file> | kubeseal \
+     --controller-name=sealed-secrets-controller \
+     --controller-namespace=kube-system \
+     --format yaml > <sealed_secret_file>
+```
+
+This will generate the new encrypted sealed-secret manifest in the file you specified with `<sealed_secret_file>`. After this please
+BE CERTAIN to delete the un-encrypted secret file, we do not want to leak these values in `git`. Finally you can move the `sealed-secret`
+to its correct location within this repo.
+
+### Common issues
+
+- `error: cannot get sealed secret service: Unauthorized`: You must be signed in to the qa cluster to be able to communicate with the sealed secrets controller.
+
 ## Community Meeting
 
 We have a weekly community meeting to discuss the project and contributions. Meeting happens **every Wednesday 10AM PST**.

--- a/argocd/overlays/applicaitons/qa.yaml
+++ b/argocd/overlays/applicaitons/qa.yaml
@@ -5,10 +5,13 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/gregory-pereira/ui.git
+    repoURL: https://github.com/instructlab/ui.git
     path: deploy/k8s/overlays/openshift/qa
-    targetRevision: argocd-deployment
+    targetRevision: main
   destination:
     namespace: instructlab
     name: in-cluster
+  syncPolicy:
+    automated:
+      selfHeal: true
 


### PR DESCRIPTION
This should point our QA manifests back to upstream and add some simple documentation on using the ss operator / controller.

After this, we can test cutting a new release and see if it redeploys