### PR TITLE
remove combining tags steps and restructure multiple tags

### DIFF
--- a/.github/workflows/pr-images.yml
+++ b/.github/workflows/pr-images.yml
@@ -97,31 +97,11 @@ jobs:
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_UI_IMAGE_NAME }}
 
-      - name: Combine GHCR Tags with PR Tag
-        id: combined_ghcr_ui_tags
-        if: ${{ steps.get_pr_number.outputs.result  != '' }}
-        run: |-
-          TAGS="${{ steps.ghcr_ui_meta.outputs.tags }}"
-          PR_TAG="pr-${{ steps.get_pr_number.outputs.result }}"
-          COMBINED_TAGS="${PR_TAG},${TAGS}"
-          echo "COMBINED_TAGS=${COMBINED_TAGS}" >> "$GITHUB_ENV"
-          echo "PR_TAG=${PR_TAG}" >> "$GITHUB_ENV"
-
       - name: Extract Quay metadata (tags, labels) for UI image
         id: quay_ui_meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_UI_IMAGE_NAME }}
-
-      - name: Combine Quay Tags with PR Tag
-        id: combined_quay_ui_tags
-        if: ${{ steps.get_pr_number.outputs.result != '' }}
-        run: |-
-          TAGS="${{ steps.quay_ui_meta.outputs.tags }}"
-          PR_TAG="pr-${{ steps.get_pr_number.outputs.result }}"
-          COMBINED_TAGS="${PR_TAG},${TAGS}"
-          echo "COMBINED_TAGS=${COMBINED_TAGS}" >> "$GITHUB_ENV"
-          echo "PR_TAG=${PR_TAG}" >> "$GITHUB_ENV" 
 
       - name: Build and push ui image to ghcr.io
         id: push-ui-ghcr
@@ -129,7 +109,9 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.combined_ghcr_ui_tags.outputs.COMBINED_TAGS }}
+          tags: |-
+            "${{ steps.ghcr_ui_meta.outputs.tags }}"
+            "${{ env.GHCR_REGISTRY }}/${{ env.GHCR_UI_IMAGE_NAME }}:pr-${{ steps.get_pr_number.outputs.result }}"
           labels: ${{ steps.ghcr_ui_meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -149,7 +131,9 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.combined_quay_ui_tags.outputs.COMBINED_TAGS }}
+          tags: |-
+            "${{ steps.quay_ui_meta.outputs.tags }}"
+            "${{ env.QUAY_REGISTRY }}/${{ env.QUAY_UI_IMAGE_NAME }}:pr-${{ steps.get_pr_number.outputs.result }}"
           labels: ${{ steps.quay_ui_meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -166,7 +150,7 @@ jobs:
       - name: Update QA Quay UI image
         id: update_qa_ui_manifest_image
         env:
-          PR_TAG: ${{ steps.combined_quay_ui_tags.outputs.PR_TAG }}
+          PR_TAG:  "pr-${{ steps.get_pr_number.outputs.result }}"
         run: |-
           sudo wget https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_linux_amd64 -O /usr/local/bin/yq
           sudo chmod +x /usr/local/bin/yq
@@ -179,7 +163,7 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.${INPUT_ORGANIZATION_DOMAIN}"
           git add deploy/k8s/overlays/openshift/qa/kustomization.yaml
-          git commit -m "[CI AUTOMATION]: Bumping QA UI image to tag: ${{ steps.combined_quay_ui_tags.outputs.PR_TAG }}" -s -S
+          git commit -m "[CI AUTOMATION]: Bumping QA UI image to tag: pr-${{ steps.get_pr_number.outputs.result }}" -s -S
           git push origin main --force
 
   build_and_publish_ps_qa_image:
@@ -203,7 +187,6 @@ jobs:
             echo "Workflow triggered by previous action commit. Skipping."
             exit 1
           fi
-          exit 0
 
       - name: Log in to the GHCR container image registry
         uses: docker/login-action@v3
@@ -265,31 +248,11 @@ jobs:
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_PS_IMAGE_NAME }}
 
-      - name: Combine GHCR Tags with PR Tag
-        id: combined_ghcr_ps_tags
-        if: ${{ steps.get_pr_number.outputs.result != '' }}
-        run: |-
-          TAGS="${{ steps.ghcr_ps_meta.outputs.tags }}"
-          PR_TAG="pr-${{ steps.get_pr_number.outputs.result }}"
-          COMBINED_TAGS="${PR_TAG},${TAGS}"
-          echo "COMBINED_TAGS=${COMBINED_TAGS}" >> "$GITHUB_ENV"
-          echo "PR_TAG=${PR_TAG}" >> "$GITHUB_ENV"
-
       - name: Extract metadata (tags, labels) for pathservice image
         id: quay_ps_meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_PS_IMAGE_NAME }}
-
-      - name: Combine GHCR Tags with PR Tag
-        id: combined_quay_ps_tags
-        if: ${{ steps.get_pr_number.outputs.result != '' }} 
-        run: |-
-          TAGS="${{ steps.quay_ps_meta.outputs.tags }}"
-          PR_TAG="pr-${{ steps.get_pr_number.outputs.result }}"
-          COMBINED_TAGS="${PR_TAG},${TAGS}"
-          echo "COMBINED_TAGS=${COMBINED_TAGS}" >> "$GITHUB_ENV"
-          echo "PR_TAG=${PR_TAG}" >> "$GITHUB_ENV"
 
       - name: Build and push QA PS image to ghcr.io
         id: push-ps-ghcr
@@ -297,7 +260,9 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.combined_ghcr_ps_tags.outputs.COMBINED_TAGS }}
+          tags: |
+            "${{ steps.ghcr_ps_meta.outputs.tags }}"
+            "${{ env.GHCR_REGISTRY }}/${{ env.GHCR_PS_IMAGE_NAME }}:pr-${{ steps.get_pr_number.outputs.result }}"
           labels: ${{ steps.ghcr_ps_meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -317,7 +282,9 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.combined_quay_ps_tags.outputs.COMBINED_TAGS }}
+          tags: |
+            "${{ steps.quay_ps_meta.outputs.tags }}"
+            "${{ env.QUAY_REGISTRY }}/${{ env.QUAY_PS_IMAGE_NAME }}:pr-${{ steps.get_pr_number.outputs.result }}"
           labels: ${{ steps.quay_ps_meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -334,7 +301,7 @@ jobs:
       - name: Update QA PS Quay image
         id: update_qa_ps_manifest_image
         env:
-          PR_TAG: ${{ steps.combined_quay_ps_tags.outputs.PR_TAG }}
+          PR_TAG: "pr-${{ steps.get_pr_number.outputs.result }}"
         run: |-
           sudo wget https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_linux_amd64 -O /usr/local/bin/yq
           sudo chmod +x /usr/local/bin/yq
@@ -347,5 +314,5 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.${INPUT_ORGANIZATION_DOMAIN}"
           git add deploy/k8s/overlays/openshift/qa/kustomization.yaml
-          git commit -m "[CI AUTOMATION]: Bumping QA PS image to tag: ${{ steps.combined_quay_ps_tags.outputs.PR_TAG }}" -s -S
+          git commit -m "[CI AUTOMATION]: Bumping QA PS image to tag: pr-${{ steps.get_pr_number.outputs.result }}" -s -S
           git push origin main --force

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -62,16 +62,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: "${{ env.GHCR_REGISTRY }}/${{ env.GHCR_UI_IMAGE_NAME }}"
-  
-      - name: Combine GHCR Tags with PR Tag
-        id: combined_ghcr_ui_tags
-        if: ${{steps.get_release_tag.outputs.result != '' }}
-        run: |-
-          TAGS="${{ steps.ghcr_ui_meta.outputs.tags }}"
-          RELEASE_TAG="release-${{ steps.get_release_tag.outputs.RELEASE_TAG }}"
-          COMBINED_TAGS="${RELEASE_TAG},${TAGS}"
-          echo "COMBINED_TAGS=${COMBINED_TAGS}" >> "$GITHUB_ENV"
-          echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
 
       - name: Extract metadata (tags, labels) for UI image
         id: quay_ui_meta
@@ -79,23 +69,15 @@ jobs:
         with:
           images: ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_UI_IMAGE_NAME }}
 
-      - name: Combine Quay Tags with PR Tag
-        id: combined_quay_ui_tags
-        if: ${{ steps.get_release_tag.outputs.result != '' }}
-        run: |-
-          TAGS="${{ steps.quay_ui_meta.outputs.tags }}"
-          RELEASE_TAG="release-${{ steps.get_release_tag.outputs.result }}"
-          COMBINED_TAGS="${RELEASE_TAG},${TAGS}"
-          echo "COMBINED_TAGS=${COMBINED_TAGS}" >> "$GITHUB_ENV"
-          echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
-
       - name: Build and push ui image to ghcr.io
         id: push-ui-ghcr
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ${{ steps.combined_ghcr_ui_tags.outputs.COMBINED_TAGS }}
+          tags: |-
+            "${{ steps.ghcr_ui_meta.outputs.tags }}"
+            "${{ env.GHCR_REGISTRY }}/${{ env.GHCR_UI_IMAGE_NAME }}:${{ steps.get_release_tag.outputs.RELEASE_TAG }}"
           labels: ${{ steps.ghcr_ui_meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -115,7 +97,9 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.combined_quay_ui_tags.outputs.COMBINED_TAGS }}
+          tags: |-
+              "${{ steps.quay_ui_meta.outputs.tags }}"
+              "${{ env.QUAY_REGISTRY }}/${{ env.QUAY_UI_IMAGE_NAME }}:${{ steps.get_release_tag.outputs.RELEASE_TAG }}"
           labels: ${{ steps.quay_ui_meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -132,7 +116,7 @@ jobs:
       - name: Update Prod Quay PS image
         id: update_prod_ui_manifest_image
         env:
-          RELEASE_TAG: ${{ steps.combined_quay_ui_tags.outputs.RELEASE_TAG }}
+          RELEASE_TAG: ${{ steps.get_release_tag.outputs.RELEASE_TAG }}
         run: |-
           sudo wget https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_linux_amd64 -O /usr/local/bin/yq
           sudo chmod +x /usr/local/bin/yq
@@ -145,7 +129,7 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.${INPUT_ORGANIZATION_DOMAIN}"
           git add deploy/k8s/overlays/openshift/prod/kustomization.yaml
-          git commit -m "[CI AUTOMATION]: Bumping Prod UI image to tag: ${{ steps.combined_quay_ui_tags.outputs.RELEASE_TAG }}" -s -S
+          git commit -m "[CI AUTOMATION]: Bumping Prod UI image to tag: ${{ steps.get_release_tag.outputs.RELEASE_TAG }}" -s -S
           git push origin main --force
 
   build_and_publish_ps_prod_image:
@@ -198,16 +182,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_PS_IMAGE_NAME }}
-  
-      - name: Combine GHCR Tags with PR Tag
-        id: combined_ghcr_ps_tags
-        if: ${{ steps.get_release_tag.outputs.result != '' }}
-        run: |-
-          TAGS="${{ steps.ghcr_ps_meta.outputs.tags }}"
-          RELEASE_TAG="release-${{ steps.get_release_tag.outputs.RELEASE_TAG }}"
-          COMBINED_TAGS="${RELEASE_TAG},${TAGS}"
-          echo "COMBINED_TAGS=${COMBINED_TAGS}" >> "$GITHUB_ENV"
-          echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
 
       - name: Extract metadata (tags, labels) for PS image
         id: quay_ps_meta
@@ -215,23 +189,15 @@ jobs:
         with:
           images: ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_PS_IMAGE_NAME }}
 
-      - name: Combine Quay Tags with PR Tag
-        id: combined_quay_ps_tags
-        if: ${{ steps.get_release_tag.outputs.result != '' }}
-        run: |-
-          TAGS="${{ steps.quay_ps_meta.outputs.tags }}"
-          RELEASE_TAG="release-${{ steps.get_release_tag.outputs.result }}"
-          COMBINED_TAGS="${RELEASE_TAG},${TAGS}"
-          echo "COMBINED_TAGS=${COMBINED_TAGS}" >> "$GITHUB_ENV"
-          echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
-
       - name: Build and push ps image to ghcr.io
         id: push-ps-ghcr
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ${{ steps.combined_ghcr_ps_tags.outputs.COMBINED_TAGS }}
+          tags: |-
+            "${{ steps.ghcr_ps_meta.outputs.tags }}"
+            "${{ env.GHCR_REGISTRY }}/${{ env.GHCR_PS_IMAGE_NAME }}:${{ steps.get_release_tag.outputs.RELEASE_TAG }}"
           labels: ${{ steps.ghcr_ps_meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -251,7 +217,9 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.combined_quay_ps_tags.outputs.COMBINED_TAGS }}
+          tags: |-
+            "${{ steps.quay_ps_meta.outputs.tags }}"
+            "${{ env.QUAY_REGISTRY }}/${{ env.QUAY_PS_IMAGE_NAME }}:${{ steps.get_release_tag.outputs.RELEASE_TAG }}"
           labels: ${{ steps.quay_ps_meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -268,7 +236,7 @@ jobs:
       - name: Update Prod Quay PS image
         id: update_prod_ps_manifest_image
         env:
-          RELEASE_TAG: ${{ steps.combined_quay_ps_tags.outputs.RELEASE_TAG }}
+          RELEASE_TAG: ${{ steps.get_release_tag.outputs.RELEASE_TAG }}
         run: |-
           sudo wget https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_linux_amd64 -O /usr/local/bin/yq
           sudo chmod +x /usr/local/bin/yq
@@ -281,5 +249,5 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.${INPUT_ORGANIZATION_DOMAIN}"
           git add deploy/k8s/overlays/openshift/prod/kustomization.yaml
-          git commit -m "[CI AUTOMATION]: Bumping Prod PS image to tag: ${{ steps.combined_quay_ps_tags.outputs.RELEASE_TAG }}" -s -S
+          git commit -m "[CI AUTOMATION]: Bumping Prod PS image to tag: ${{ steps.get_release_tag.outputs.RELEASE_TAG }}" -s -S
           git push origin main --force

--- a/deploy/k8s/base/pathservice/deployment.yaml
+++ b/deploy/k8s/base/pathservice/deployment.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: pathservice
-          image: quay.io/instructlab-ui/pathservice:main
+          image: quay.io/instructlab-ui/pathservice:PATCHED_FROM_OVERLAYS
           imagePullPolicy: Always
           resources:
             requests:

--- a/deploy/k8s/base/ui/deployment.yaml
+++ b/deploy/k8s/base/ui/deployment.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: ui
-          image: quay.io/instructlab-ui/ui:main
+          image: quay.io/instructlab-ui/ui:PATCHED_FROM_OVERLAYS
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
Previous workflow failed, see logs: https://github.com/instructlab/ui/actions/runs/11862220666/job/33061144701#step:13:213.

The issue here was that the extracted tag data from one of the `"${{ steps.ghcr_ui_meta.outputs.tags }}"` values resolves to something like `quay.io/instructlab-ui/pathservice:main` where as the combined tags got only the image tag, resolving to `pr-334`. This is why it would complain because it thinks the whole image ref was pr-334 and so it couldn't build. I have refactored my approach to the tagging which I think should work, and refactored for simplicity.

cc @vishnoianil @nerdalert 