### PR TITLE
removing force push and push through token

### DIFF
--- a/.github/workflows/pr-images.yml
+++ b/.github/workflows/pr-images.yml
@@ -161,9 +161,10 @@ jobs:
         run: |-
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.${INPUT_ORGANIZATION_DOMAIN}"
+          git remote add origin-push https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git add deploy/k8s/overlays/openshift/qa/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping QA UI image to tag: pr-${{ steps.get_pr_number.outputs.result }}" -s
-          git push origin main --force
+          git push origin-push main
 
   build_and_publish_ps_qa_image:
     name: Push QA pathservice container image to GHCR and QUAY
@@ -312,6 +313,7 @@ jobs:
         run: |-
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.${INPUT_ORGANIZATION_DOMAIN}"
+          git remote add origin-push https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git add deploy/k8s/overlays/openshift/qa/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping QA PS image to tag: pr-${{ steps.get_pr_number.outputs.result }}" -s
-          git push origin main --force
+          git push origin-push main

--- a/.github/workflows/pr-images.yml
+++ b/.github/workflows/pr-images.yml
@@ -20,7 +20,7 @@ jobs:
     environment: registry-creds
     permissions:
       packages: write
-      contents: read
+      contents: write
       attestations: write
       id-token: write
 
@@ -172,7 +172,7 @@ jobs:
     environment: registry-creds
     permissions:
       packages: write
-      contents: read
+      contents: write
       attestations: write
       id-token: write
 

--- a/.github/workflows/pr-images.yml
+++ b/.github/workflows/pr-images.yml
@@ -161,10 +161,9 @@ jobs:
         run: |-
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.${INPUT_ORGANIZATION_DOMAIN}"
-          git remote add origin-push https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git add deploy/k8s/overlays/openshift/qa/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping QA UI image to tag: pr-${{ steps.get_pr_number.outputs.result }}" -s
-          git push origin-push main
+          git push origin main
 
   build_and_publish_ps_qa_image:
     name: Push QA pathservice container image to GHCR and QUAY
@@ -313,7 +312,6 @@ jobs:
         run: |-
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.${INPUT_ORGANIZATION_DOMAIN}"
-          git remote add origin-push https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git add deploy/k8s/overlays/openshift/qa/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping QA PS image to tag: pr-${{ steps.get_pr_number.outputs.result }}" -s
-          git push origin-push main
+          git push origin main

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -128,9 +128,10 @@ jobs:
         run: |-
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.${INPUT_ORGANIZATION_DOMAIN}"
+          git remote add origin-push https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git add deploy/k8s/overlays/openshift/prod/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping Prod UI image to tag: ${{ steps.get_release_tag.outputs.RELEASE_TAG }}" -s
-          git push origin main --force
+          git push origin-push main
 
   build_and_publish_ps_prod_image:
     name: Push UI container image to GHCR and QUAY
@@ -248,6 +249,7 @@ jobs:
         run: |-
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.${INPUT_ORGANIZATION_DOMAIN}"
+          git remote add origin-push https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git add deploy/k8s/overlays/openshift/prod/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping Prod PS image to tag: ${{ steps.get_release_tag.outputs.RELEASE_TAG }}" -s
-          git push origin main --force
+          git push origin-push main

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -128,10 +128,9 @@ jobs:
         run: |-
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.${INPUT_ORGANIZATION_DOMAIN}"
-          git remote add origin-push https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git add deploy/k8s/overlays/openshift/prod/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping Prod UI image to tag: ${{ steps.get_release_tag.outputs.RELEASE_TAG }}" -s
-          git push origin-push main
+          git push origin main
 
   build_and_publish_ps_prod_image:
     name: Push UI container image to GHCR and QUAY
@@ -249,7 +248,6 @@ jobs:
         run: |-
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.${INPUT_ORGANIZATION_DOMAIN}"
-          git remote add origin-push https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git add deploy/k8s/overlays/openshift/prod/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping Prod PS image to tag: ${{ steps.get_release_tag.outputs.RELEASE_TAG }}" -s
-          git push origin-push main
+          git push origin main

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -18,7 +18,7 @@ jobs:
     environment: registry-creds
     permissions:
       packages: write
-      contents: read
+      contents: write
       attestations: write
       id-token: write
 
@@ -139,7 +139,7 @@ jobs:
     environment: registry-creds
     permissions:
       packages: write
-      contents: read
+      contents: write
       attestations: write
       id-token: write
 


### PR DESCRIPTION
cc @vishnoianil @nerdalert 

Workflow was not working due to auth, It seems github actions bot cannot push to main. I have opted to reconstruct the remote using the `secrets.GITHUB_TOKEN`, although I dont know what token this or what permissions it has. I also removed the force push to be on the safe side.

Ref to previous failed job run: https://github.com/instructlab/ui/actions/runs/11882953745/job/33109072941

Logs:
```
[main c17732d] [CI AUTOMATION]: Bumping QA UI image to tag: pr-347
 1 file changed, 1 insertion(+), 1 deletion(-)
remote: Permission to instructlab/ui.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/instructlab/ui/': The requested URL returned error: [40](https://github.com/instructlab/ui/actions/runs/11882953745/job/33109072941#step:16:41)3
```