### PR TITLE
use platform-engineering-bot for image workflows

### DIFF
--- a/.github/workflows/pr-images.yml
+++ b/.github/workflows/pr-images.yml
@@ -159,9 +159,9 @@ jobs:
 
       - name: Commit and push bump QA UI Image manifest
         run: |-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote add origin-push https://github-actions[bot]:${{ secrets.GITHUB_TOKEN }}@github.com/instructlab/ui.git
+          git config user.name "platform-engineering-bot"
+          git config user.email "platform-engineering@redhat.com"
+          git remote add origin-push https://platform-engineering-bot:${{ secrets.BOT_PAT }}@github.com/instructlab/ui.git
           git add deploy/k8s/overlays/openshift/qa/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping QA UI image to tag: pr-${{ steps.get_pr_number.outputs.result }}" -s
           git push origin-push main
@@ -311,9 +311,9 @@ jobs:
 
       - name: Commit and push bump QA PS Image manifest
         run: |-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote add origin-push https://github-actions[bot]:${{ secrets.GITHUB_TOKEN }}@github.com/instructlab/ui.git
+          git config user.name "platform-engineering-bot"
+          git config user.email "platform-engineering@redhat.com"
+          git remote add origin-push https://platform-engineering-bot:${{ secrets.BOT_PAT }}@github.com/instructlab/ui.git
           git add deploy/k8s/overlays/openshift/qa/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping QA PS image to tag: pr-${{ steps.get_pr_number.outputs.result }}" -s
           git push origin-push main

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -126,9 +126,9 @@ jobs:
 
       - name: Commit and push bump to Prod UI image manifest
         run: |-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote add origin-push https://github-actions[bot]:${{ secrets.GITHUB_TOKEN }}@github.com/instructlab/ui.git
+          git config user.name "platform-engineering-bot"
+          git config user.email "platform-engineering@redhat.com"
+          git remote add origin-push https://platform-engineering-bot:${{ secrets.BOT_PAT }}@github.com/instructlab/ui.git
           git add deploy/k8s/overlays/openshift/prod/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping Prod UI image to tag: ${{ steps.get_release_tag.outputs.RELEASE_TAG }}" -s
           git push origin-push main
@@ -247,9 +247,9 @@ jobs:
 
       - name: Commit and push bump to Prod PS image manifest
         run: |-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote add origin-push https://github-actions[bot]:${{ secrets.GITHUB_TOKEN }}@github.com/instructlab/ui.git
+          git config user.name "platform-engineering-bot"
+          git config user.email "platform-engineering@redhat.com"
+          git remote add origin-push https://platform-engineering-bot:${{ secrets.BOT_PAT }}@github.com/instructlab/ui.git
           git add deploy/k8s/overlays/openshift/prod/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping Prod PS image to tag: ${{ steps.get_release_tag.outputs.RELEASE_TAG }}" -s
           git push origin-push main


### PR DESCRIPTION
cc @nerdalert @vishnoianil 

This will use the `platform-engineering-bot` user which I have enabled to push to main, and setup the `BOT_PAT` secret with its personal access token.