### PR TITLE
allow pull --ff-only to avoid collisions

### DIFF
--- a/.github/workflows/pr-images.yml
+++ b/.github/workflows/pr-images.yml
@@ -164,6 +164,7 @@ jobs:
         run: |-
           git config user.name "platform-engineering-bot"
           git config user.email "platform-engineering@redhat.com"
+          git pull --ff-only
           git add deploy/k8s/overlays/openshift/qa/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping QA UI image to tag: pr-${{ steps.get_pr_number.outputs.result }}" -s
           git push origin main
@@ -318,6 +319,7 @@ jobs:
         run: |-
           git config user.name "platform-engineering-bot"
           git config user.email "platform-engineering@redhat.com"
+          git pull --ff-only
           git add deploy/k8s/overlays/openshift/qa/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping QA PS image to tag: pr-${{ steps.get_pr_number.outputs.result }}" -s
           git push origin main

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -23,8 +23,17 @@ jobs:
       id-token: write
 
     steps:
+      - name: Extract Release Tag
+        id: get_release_tag
+        run: |-
+          RELEASE_TAG="release-${{ github.event.release.tag_name }}"
+          echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
+
       - name: Check out the repo
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.BOT_PAT }}
+          ref: "${{ steps.get_release_tag.outputs.RELEASE_TAG }}"
 
       - name: Log in to the GHCR container image registry
         uses: docker/login-action@v3
@@ -50,12 +59,6 @@ jobs:
           key: "${{ runner.os }}-buildx-${{ github.sha }}"
           restore-keys: |-
             "${{ runner.os }}-buildx-"
-
-      - name: Extract Release Tag
-        id: get_release_tag
-        run: |-
-          RELEASE_TAG="release-${{ github.event.release.tag_name }}"
-          echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
 
       - name: Extract metadata (tags, labels) for UI image
         id: ghcr_ui_meta
@@ -112,6 +115,12 @@ jobs:
           subject-name: ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_UI_IMAGE_NAME}}
           subject-digest: ${{ steps.push-ui-quay.outputs.digest }}
           push-to-registry: true
+      
+      - name: Re-Checkout main on the repo
+        uses: actions/checkout@v4
+        with:
+          token: "${{ secrets.BOT_PAT }}"
+          ref: "main"
 
       - name: Update Prod Quay PS image
         id: update_prod_ui_manifest_image
@@ -128,10 +137,10 @@ jobs:
         run: |-
           git config user.name "platform-engineering-bot"
           git config user.email "platform-engineering@redhat.com"
-          git remote add origin-push https://platform-engineering-bot:${{ secrets.BOT_PAT }}@github.com/instructlab/ui.git
+          git pull --ff-only
           git add deploy/k8s/overlays/openshift/prod/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping Prod UI image to tag: ${{ steps.get_release_tag.outputs.RELEASE_TAG }}" -s
-          git push origin-push main
+          git push origin main
 
   build_and_publish_ps_prod_image:
     name: Push UI container image to GHCR and QUAY
@@ -144,8 +153,17 @@ jobs:
       id-token: write
 
     steps:
+      - name: Extract Release Tag
+        id: get_release_tag
+        run: |-
+          RELEASE_TAG="release-${{ github.event.release.tag_name }}"
+          echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
+
       - name: Check out the repo
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.BOT_PAT }}
+          ref: "${{ steps.get_release_tag.outputs.RELEASE_TAG }}"
 
       - name: Log in to the GHCR container image registry
         uses: docker/login-action@v3
@@ -171,12 +189,6 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-
-      - name: Extract Release Tag
-        id: get_release_tag
-        run: |-
-          RELEASE_TAG="release-${{ github.event.release.tag_name }}"
-          echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
 
       - name: Extract metadata (tags, labels) for PS image
         id: ghcr_ps_meta
@@ -233,6 +245,12 @@ jobs:
           subject-name: ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_PS_IMAGE_NAME}}
           subject-digest: ${{ steps.push-ps-quay.outputs.digest }}
           push-to-registry: true
+
+      - name: Checkout main on the repo
+        uses: actions/checkout@v4
+        with:
+          token: "${{ secrets.BOT_PAT }}"
+          ref: "main"
         
       - name: Update Prod Quay PS image
         id: update_prod_ps_manifest_image
@@ -249,7 +267,7 @@ jobs:
         run: |-
           git config user.name "platform-engineering-bot"
           git config user.email "platform-engineering@redhat.com"
-          git remote add origin-push https://platform-engineering-bot:${{ secrets.BOT_PAT }}@github.com/instructlab/ui.git
+          git pull --ff-only
           git add deploy/k8s/overlays/openshift/prod/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping Prod PS image to tag: ${{ steps.get_release_tag.outputs.RELEASE_TAG }}" -s
-          git push origin-push main
+          git push origin main


### PR DESCRIPTION
cc @vishnoianil 

basically what is happening, is that the pathservice image bump commit merges, and this causes conflicts for the UI one. There for I added `git pull --ff-only` to the job to allow it to fast forward to that commit, and avoid conflicts