### PR TITLE
[FIX] move fast-forward pull before changes to avoid conflict

### DIFF
--- a/.github/workflows/pr-images.yml
+++ b/.github/workflows/pr-images.yml
@@ -149,6 +149,10 @@ jobs:
           subject-digest: ${{ steps.push-ui-quay.outputs.digest }}
           push-to-registry: true
 
+      - name: Update coderefs before code changes
+        run: |-
+          git pull --ff-only
+
       - name: Update QA Quay UI image
         id: update_qa_ui_manifest_image
         env:
@@ -164,7 +168,6 @@ jobs:
         run: |-
           git config user.name "platform-engineering-bot"
           git config user.email "platform-engineering@redhat.com"
-          git pull --ff-only
           git add deploy/k8s/overlays/openshift/qa/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping QA UI image to tag: pr-${{ steps.get_pr_number.outputs.result }}" -s
           git push origin main
@@ -304,6 +307,11 @@ jobs:
           subject-digest: ${{ steps.push-ps-quay.outputs.digest }}
           push-to-registry: true
 
+      
+      - name: Update coderefs before code changes
+        run: |-
+          git pull --ff-only
+
       - name: Update QA PS Quay image
         id: update_qa_ps_manifest_image
         env:
@@ -319,7 +327,6 @@ jobs:
         run: |-
           git config user.name "platform-engineering-bot"
           git config user.email "platform-engineering@redhat.com"
-          git pull --ff-only
           git add deploy/k8s/overlays/openshift/qa/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping QA PS image to tag: pr-${{ steps.get_pr_number.outputs.result }}" -s
           git push origin main

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -122,6 +122,10 @@ jobs:
           token: "${{ secrets.BOT_PAT }}"
           ref: "main"
 
+      - name: Update coderefs before code changes
+        run: |-
+          git pull --ff-only
+
       - name: Update Prod Quay PS image
         id: update_prod_ui_manifest_image
         env:
@@ -137,7 +141,6 @@ jobs:
         run: |-
           git config user.name "platform-engineering-bot"
           git config user.email "platform-engineering@redhat.com"
-          git pull --ff-only
           git add deploy/k8s/overlays/openshift/prod/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping Prod UI image to tag: ${{ steps.get_release_tag.outputs.RELEASE_TAG }}" -s
           git push origin main
@@ -251,6 +254,10 @@ jobs:
         with:
           token: "${{ secrets.BOT_PAT }}"
           ref: "main"
+
+      - name: Update coderefs before code changes
+        run: |-
+          git pull --ff-only
         
       - name: Update Prod Quay PS image
         id: update_prod_ps_manifest_image
@@ -267,7 +274,6 @@ jobs:
         run: |-
           git config user.name "platform-engineering-bot"
           git config user.email "platform-engineering@redhat.com"
-          git pull --ff-only
           git add deploy/k8s/overlays/openshift/prod/kustomization.yaml
           git commit -m "[CI AUTOMATION]: Bumping Prod PS image to tag: ${{ steps.get_release_tag.outputs.RELEASE_TAG }}" -s
           git push origin main


### PR DESCRIPTION
The issue with this was that I was modifying the manifests with the pr tag before `pull`ing to fast forward and pick up any other CI changes. Here is an example log:
```
From https://github.com/instructlab/ui
   49cad10..9e14ad2  main        -> origin/main
 * [new branch]      dependabot/npm_and_yarn/main/fortawesome/fontawesome-svg-core-6.7.1 -> origin/dependabot/npm_and_yarn/main/fortawesome/fontawesome-svg-core-6.7.1
 * [new branch]      release-1.0 -> origin/release-1.0
 * [new branch]      streamline-release-images-workflow -> origin/streamline-release-images-workflow
 * [new tag]         v1.0.0-beta.0 -> v1.0.0-beta.0
 * [new tag]         v1.0.0-beta.1 -> v1.0.0-beta.1
 * [new tag]         v1.0.0-beta.2 -> v1.0.0-beta.2
 * [new tag]         v1.0.0-beta.3 -> v1.0.0-beta.3
error: Your local changes to the following files would be overwritten by merge:
	deploy/k8s/overlays/openshift/qa/kustomization.yaml
Please commit your changes or stash them before you merge.
Aborting
Updating [49](https://github.com/instructlab/ui/actions/runs/12016449930/job/33496664430#step:16:50)cad10..9e14ad2
```
From:  https://github.com/instructlab/ui/actions/runs/12016449930/job/33496664430#step:16:40.

This PR moves the `git pull --ff-only` before the code changes so there should be no working changes in the tree to cause conflicts.

cc @nerdalert @vishnoianil 