### PR TITLE
remove CI_AUTOMATION workflow errors by checking skip

### DIFF
--- a/.github/workflows/pr-images.yml
+++ b/.github/workflows/pr-images.yml
@@ -32,14 +32,17 @@ jobs:
           ref: 'main'
 
       - name: Skip if triggered by GitHub Actions bot
-        id: check-skip
+        id: check_skip
         run: |-
-          if [[ "$(git log -1 --pretty=format:'%s')" == *"[CI AUTOMATION]:"* ]]; then
-            echo "Workflow triggered by previous action commit. Skipping."
-            exit 1
-          fi
+            if [[ "$(git log -1 --pretty=format:'%s')" == *"[CI AUTOMATION]:"* ]]; then
+              echo "Workflow triggered by previous action commit. Skipping."
+              echo "skip_workflow=true" >> "$GITHUB_ENV"
+            else
+              echo "skip_workflow=false" >> "$GITHUB_ENV"
+            fi
 
       - name: Log in to the GHCR container image registry
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         uses: docker/login-action@v3
         with:
           registry: "${{ env.GHCR_REGISTRY }}"
@@ -47,6 +50,7 @@ jobs:
           password: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Log in to the Quay container image registry
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         uses: docker/login-action@v3
         with:
           registry: "${{ env.QUAY_REGISTRY }}"
@@ -54,9 +58,11 @@ jobs:
           password: "${{ secrets.QUAY_TOKEN }}"
 
       - name: Set up Docker Buildx
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
@@ -65,6 +71,7 @@ jobs:
             "${{ runner.os }}-buildx-"
 
       - name: Get Pull Request Number from Commit
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         id: get_pr_number
         uses: actions/github-script@v7
         with:
@@ -94,18 +101,21 @@ jobs:
             return '';
 
       - name: Extract GHCR metadata (tags, labels) for UI image
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         id: ghcr_ui_meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_UI_IMAGE_NAME }}
 
       - name: Extract Quay metadata (tags, labels) for UI image
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         id: quay_ui_meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_UI_IMAGE_NAME }}
 
       - name: Build and push ui image to ghcr.io
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         id: push-ui-ghcr
         uses: docker/build-push-action@v6
         with:
@@ -121,6 +131,7 @@ jobs:
           file: src/Containerfile
 
       - name: Generate GHCR artifact attestation
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_UI_IMAGE_NAME}}
@@ -128,6 +139,7 @@ jobs:
           push-to-registry: true
 
       - name: Build and push ui image to quay.io
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         id: push-ui-quay
         uses: docker/build-push-action@v6
         with:
@@ -143,6 +155,7 @@ jobs:
           file: src/Containerfile
 
       - name: Generate QA UI Quay artifact attestation
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_UI_IMAGE_NAME}}
@@ -150,10 +163,12 @@ jobs:
           push-to-registry: true
 
       - name: Update coderefs before code changes
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         run: |-
           git pull --ff-only
 
       - name: Update QA Quay UI image
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         id: update_qa_ui_manifest_image
         env:
           PR_TAG:  "pr-${{ steps.get_pr_number.outputs.result }}"
@@ -165,6 +180,7 @@ jobs:
           ' deploy/k8s/overlays/openshift/qa/kustomization.yaml
 
       - name: Commit and push bump QA UI Image manifest
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         run: |-
           git config user.name "platform-engineering-bot"
           git config user.email "platform-engineering@redhat.com"
@@ -190,14 +206,17 @@ jobs:
           ref: 'main'
 
       - name: Skip if triggered by GitHub Actions bot
-        id: check-skip
+        id: check_skip
         run: |-
-          if [[ "$(git log -1 --pretty=format:'%s')" == *"[CI AUTOMATION]:"* ]]; then
-            echo "Workflow triggered by previous action commit. Skipping."
-            exit 1
-          fi
+            if [[ "$(git log -1 --pretty=format:'%s')" == *"[CI AUTOMATION]:"* ]]; then
+              echo "Workflow triggered by previous action commit. Skipping."
+              echo "skip_workflow=true" >> "$GITHUB_ENV"
+            else
+              echo "skip_workflow=false" >> "$GITHUB_ENV"
+            fi
 
       - name: Log in to the GHCR container image registry
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.GHCR_REGISTRY }}
@@ -205,6 +224,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to the Quay container image registry
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.QUAY_REGISTRY }}
@@ -212,9 +232,11 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Set up Docker Buildx
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
@@ -223,6 +245,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Get Pull Request Number from Commit
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         id: get_pr_number
         uses: actions/github-script@v7
         with:
@@ -252,18 +275,21 @@ jobs:
             return '';
 
       - name: Extract metadata (tags, labels) for pathservice image
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         id: ghcr_ps_meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_PS_IMAGE_NAME }}
 
       - name: Extract metadata (tags, labels) for pathservice image
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         id: quay_ps_meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_PS_IMAGE_NAME }}
 
       - name: Build and push QA PS image to ghcr.io
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         id: push-ps-ghcr
         uses: docker/build-push-action@v6
         with:
@@ -279,6 +305,7 @@ jobs:
           file: pathservice/Containerfile
 
       - name: Generate QA PS GHCR artifact attestation
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_PS_IMAGE_NAME}}
@@ -286,6 +313,7 @@ jobs:
           push-to-registry: true
 
       - name: Build and push QA PS image to quay.io
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         id: push-ps-quay
         uses: docker/build-push-action@v6
         with:
@@ -301,6 +329,7 @@ jobs:
           file: pathservice/Containerfile
 
       - name: Generate QA PS Quay artifact attestation
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ env.QUAY_REGISTRY }}/${{ env.QUAY_PS_IMAGE_NAME}}
@@ -309,10 +338,12 @@ jobs:
 
       
       - name: Update coderefs before code changes
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         run: |-
           git pull --ff-only
 
       - name: Update QA PS Quay image
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         id: update_qa_ps_manifest_image
         env:
           PR_TAG: "pr-${{ steps.get_pr_number.outputs.result }}"
@@ -324,6 +355,7 @@ jobs:
           ' deploy/k8s/overlays/openshift/qa/kustomization.yaml
 
       - name: Commit and push bump QA PS Image manifest
+        if: steps.check_skip.outputs.skip_workflow == 'false'
         run: |-
           git config user.name "platform-engineering-bot"
           git config user.email "platform-engineering@redhat.com"


### PR DESCRIPTION
Currently what is happening: A PR gets merged, which through CI triggers a commit to bump and push the deployment manifests with new updated image tag, which triggers the same workflow. At this point I previously chose to fail the workflow but that looks ugly in CI, as well as produces false positives for debugging - making me think some of those actions are actually failing and not just cutting short as intended. This code change should make it such the workflow still succeeds it would just only have 1 job. This is the only job that needs it as all the others either look for different push paths or are triggered on release.

cc @vishnoianil @nerdalert 