### PR TITLE
updating umami argocd app to use prod overlay and cluster

### DIFF
--- a/argocd/overlays/applicaitons/umami.yaml
+++ b/argocd/overlays/applicaitons/umami.yaml
@@ -6,7 +6,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/instructlab/ui.git
-    path: deploy/k8s/overlays/openshift/umami
+    path: deploy/k8s/overlays/openshift/umami/prod
     targetRevision: main
   destination:
     namespace: umami


### PR DESCRIPTION
Relates to #406.

In the last PR I made the overlays, forgot to update the Argocd app.