### PR TITLE
deploying to prod cluster

### DIFF
--- a/argocd/overlays/applicaitons/umami.yaml
+++ b/argocd/overlays/applicaitons/umami.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: umami
+  name: umami-prod
 spec:
   project: default
   source:
@@ -10,7 +10,7 @@ spec:
     targetRevision: main
   destination:
     namespace: umami
-    name: in-cluster
+    name: instructlab-ui-prod
   syncPolicy:
     automated:
       selfHeal: true


### PR DESCRIPTION
one more update @vishnoianil 

Argocd cannot decrypt the sealed secret on the QA cluster because of course this sealed-secret was created and encrypted on the Prod cluster. This change should update our Umami deployment to be deployed on the prod cluster which is what we want anyway