### PR TITLE
Increase the wizard component height

### DIFF
--- a/src/components/Contribute/Knowledge/knowledge.css
+++ b/src/components/Contribute/Knowledge/knowledge.css
@@ -37,3 +37,11 @@
 .knowledge-form {
   line-height: 3;
 }
+
+.pf-v6-c-wizard {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  min-height: 60vh;
+  overflow: hidden;
+}


### PR DESCRIPTION
Too smoll.

Before:
<img width="1262" alt="image" src="https://github.com/user-attachments/assets/92b25382-fc05-4c0f-9734-86ffa0b5903e" />
After:
<img width="1255" alt="image" src="https://github.com/user-attachments/assets/35a2c3ca-27a1-4f24-a463-38afbcbabbc5" />
