### PR TITLE
Add knowledge form context selection

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/api/native/git/knowledge-files/route.ts
+++ b/src/app/api/native/git/knowledge-files/route.ts
@@ -1,5 +1,6 @@
 // src/app/api/native/git/knowledge-files/route.ts
 
+'use server';
 import { NextRequest, NextResponse } from 'next/server';
 import * as git from 'isomorphic-git';
 import fs from 'fs';
@@ -68,7 +69,7 @@ const listAllBranches = async (): Promise<Branch[]> => {
  * @returns An array of KnowledgeFile objects.
  */
 const getKnowledgeFiles = async (branchName: string): Promise<KnowledgeFile[]> => {
-  const REPO_DIR = LOCAL_TAXONOMY_DOCS_ROOT_DIR;
+  const REPO_DIR = path.join(LOCAL_TAXONOMY_DOCS_ROOT_DIR, '/taxonomy-knowledge-docs');
 
   // Ensure the repository path exists
   if (!fs.existsSync(REPO_DIR)) {

--- a/src/app/api/native/git/knowledge-files/route.ts
+++ b/src/app/api/native/git/knowledge-files/route.ts
@@ -1,0 +1,211 @@
+// src/app/api/native/git/knowledge-files/route.ts
+
+import { NextRequest, NextResponse } from 'next/server';
+import * as git from 'isomorphic-git';
+import fs from 'fs';
+import path from 'path';
+
+// Constants for repository paths
+const LOCAL_TAXONOMY_DOCS_ROOT_DIR =
+  process.env.NEXT_PUBLIC_LOCAL_TAXONOMY_DOCS_ROOT_DIR || `${process.env.HOME}/.instructlab-ui/taxonomy-knowledge-docs`;
+
+// Interface for the response
+interface KnowledgeFile {
+  filename: string;
+  content: string;
+  commitSha: string;
+  commitDate: string;
+}
+
+interface Branch {
+  name: string;
+  commitSha: string;
+  commitDate: string;
+}
+
+/**
+ * Function to list all branches.
+ */
+const listAllBranches = async (): Promise<Branch[]> => {
+  const REPO_DIR = LOCAL_TAXONOMY_DOCS_ROOT_DIR;
+
+  if (!fs.existsSync(REPO_DIR)) {
+    throw new Error('Repository path does not exist.');
+  }
+
+  const branches = await git.listBranches({ fs, dir: REPO_DIR });
+
+  const branchDetails: Branch[] = [];
+
+  for (const branch of branches) {
+    try {
+      const latestCommit = await git.log({ fs, dir: REPO_DIR, ref: branch, depth: 1 });
+      if (latestCommit.length === 0) {
+        continue; // No commits on this branch
+      }
+
+      const commit = latestCommit[0];
+      const commitSha = commit.oid;
+      const commitDate = new Date(commit.commit.committer.timestamp * 1000).toISOString();
+
+      branchDetails.push({
+        name: branch,
+        commitSha: commitSha,
+        commitDate: commitDate
+      });
+    } catch (error) {
+      console.error(`Failed to retrieve commit for branch ${branch}:`, error);
+      continue;
+    }
+  }
+
+  return branchDetails;
+};
+
+/**
+ * Function to retrieve knowledge files from a specific branch.
+ * @param branchName - The name of the branch to retrieve files from.
+ * @returns An array of KnowledgeFile objects.
+ */
+const getKnowledgeFiles = async (branchName: string): Promise<KnowledgeFile[]> => {
+  const REPO_DIR = LOCAL_TAXONOMY_DOCS_ROOT_DIR;
+
+  // Ensure the repository path exists
+  if (!fs.existsSync(REPO_DIR)) {
+    throw new Error('Repository path does not exist.');
+  }
+
+  // Check if the branch exists
+  const branches = await git.listBranches({ fs, dir: REPO_DIR });
+  if (!branches.includes(branchName)) {
+    throw new Error(`Branch "${branchName}" does not exist.`);
+  }
+
+  // Checkout the specified branch
+  await git.checkout({ fs, dir: REPO_DIR, ref: branchName });
+
+  // Read all files in the repository root directory
+  const allFiles = fs.readdirSync(REPO_DIR);
+
+  // Filter for Markdown files only
+  const markdownFiles = allFiles.filter((file) => path.extname(file).toLowerCase() === '.md');
+
+  const knowledgeFiles: KnowledgeFile[] = [];
+
+  for (const file of markdownFiles) {
+    const filePath = path.join(REPO_DIR, file);
+
+    // Check if the file is a regular file
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile()) {
+      continue;
+    }
+
+    try {
+      // Retrieve the latest commit SHA for the file on the specified branch
+      const logs = await git.log({
+        fs,
+        dir: REPO_DIR,
+        ref: branchName,
+        filepath: file,
+        depth: 1 // Only the latest commit
+      });
+
+      if (logs.length === 0) {
+        // No commits found for this file; skip it
+        continue;
+      }
+
+      const latestCommit = logs[0];
+      const commitSha = latestCommit.oid;
+      const commitDate = new Date(latestCommit.commit.committer.timestamp * 1000).toISOString();
+
+      // Read the file content
+      const fileContent = fs.readFileSync(filePath, 'utf-8');
+
+      knowledgeFiles.push({
+        filename: file,
+        content: fileContent,
+        commitSha: commitSha,
+        commitDate: commitDate
+      });
+    } catch (error) {
+      console.error(`Failed to retrieve commit for file ${file}:`, error);
+      // Skip files that cause errors
+      continue;
+    }
+  }
+
+  return knowledgeFiles;
+};
+
+/**
+ * Handler for GET requests.
+ * - If 'action=list-branches' is present, return all branches.
+ * - Else, return knowledge files from the 'main' branch.
+ */
+const getKnowledgeFilesHandler = async (req: NextRequest): Promise<NextResponse> => {
+  try {
+    const { searchParams } = new URL(req.url);
+    const action = searchParams.get('action');
+
+    if (action === 'list-branches') {
+      const branches = await listAllBranches();
+      return NextResponse.json({ branches }, { status: 200 });
+    }
+
+    // Default behavior: fetch files from 'main' branch
+    const branchName = 'main';
+    const knowledgeFiles = await getKnowledgeFiles(branchName);
+    return NextResponse.json({ files: knowledgeFiles }, { status: 200 });
+  } catch (error) {
+    console.error('Failed to retrieve knowledge files:', error);
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+};
+
+/**
+ * Handler for POST requests.
+ * - If 'branchName' is provided, fetch files for that branch.
+ * - If 'action=diff', fetch files from the 'main' branch.
+ * - Else, return an error.
+ */
+const postKnowledgeFilesHandler = async (req: NextRequest): Promise<NextResponse> => {
+  try {
+    const body = await req.json();
+    const { action, branchName } = body;
+
+    if (action === 'diff') {
+      // fetch files from main
+      const branchNameForDiff = 'main';
+      const knowledgeFiles = await getKnowledgeFiles(branchNameForDiff);
+      return NextResponse.json({ files: knowledgeFiles }, { status: 200 });
+    }
+
+    if (branchName && typeof branchName === 'string') {
+      // Fetch files from a specified branch
+      const knowledgeFiles = await getKnowledgeFiles(branchName);
+      return NextResponse.json({ files: knowledgeFiles }, { status: 200 });
+    }
+
+    // If no valid action or branchName is provided
+    return NextResponse.json({ error: 'Invalid request. Provide an action or branchName.' }, { status: 400 });
+  } catch (error) {
+    console.error('Failed to process POST request:', error);
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+};
+
+/**
+ * GET handler to retrieve knowledge files or list branches based on 'action' query parameter.
+ */
+export async function GET(req: NextRequest) {
+  return await getKnowledgeFilesHandler(req);
+}
+
+/**
+ * POST handler to retrieve knowledge files based on 'branchName' or 'action'.
+ */
+export async function POST(req: NextRequest) {
+  return await postKnowledgeFilesHandler(req);
+}

--- a/src/app/api/native/upload/route.ts
+++ b/src/app/api/native/upload/route.ts
@@ -6,8 +6,7 @@ import http from 'isomorphic-git/http/node';
 import path from 'path';
 import fs from 'fs';
 
-const TAXONOMY_DOCS_ROOT_DIR = process.env.NEXT_PUBLIC_TAXONOMY_ROOT_DIR || '';
-const TAXONOMY_DOCS_CONTAINER_MOUNT_DIR = '/tmp/.instructlab-ui';
+const LOCAL_TAXONOMY_DOCS_ROOT_DIR = process.env.NEXT_PUBLIC_LOCAL_TAXONOMY_ROOT_DIR || `${process.env.HOME}/.instructlab-ui`;
 const TAXONOMY_KNOWLEDGE_DOCS_REPO_URL = 'https://github.com/instructlab-public/taxonomy-knowledge-docs.git';
 
 export async function POST(req: NextRequest) {
@@ -31,10 +30,8 @@ export async function POST(req: NextRequest) {
     });
 
     // Write the files to the repository
-    const docsRepoUrlTmp = path.join(docsRepoUrl, '/');
     for (const file of filesWithTimestamp) {
-      const filePath = path.join(docsRepoUrlTmp, file.fileName);
-      console.log(`Writing file to ${filePath} in taxonomy knowledge docs repository.`);
+      const filePath = path.join(docsRepoUrl, file.fileName);
       fs.writeFileSync(filePath, file.fileContent);
     }
 
@@ -54,12 +51,9 @@ export async function POST(req: NextRequest) {
         .join(', ')}\n\nSigned-off-by: ui@instructlab.ai`
     });
 
-    console.log(`Successfully committed files to taxonomy knowledge docs repository with commit SHA: ${commitSha}`);
-
-    const origTaxonomyDocsRepoDir = path.join(TAXONOMY_DOCS_ROOT_DIR, '/taxonomy-knowledge-docs');
     return NextResponse.json(
       {
-        repoUrl: origTaxonomyDocsRepoDir,
+        repoUrl: docsRepoUrl,
         commitSha,
         documentNames: filesWithTimestamp.map((file: { fileName: string }) => file.fileName),
         prUrl: ''
@@ -67,32 +61,17 @@ export async function POST(req: NextRequest) {
       { status: 201 }
     );
   } catch (error) {
-    console.error('Failed to upload knowledge documents:', error);
-    return NextResponse.json({ error: 'Failed to upload knowledge documents' }, { status: 500 });
+    console.error('Failed to upload documents:', error);
+    return NextResponse.json({ error: 'Failed to upload documents' }, { status: 500 });
   }
 }
 
 async function cloneTaxonomyDocsRepo() {
-  // Check the location of the taxonomy repository and create the taxonomy-docs-repository parallel to that.
-  let remoteTaxonomyRepoDirFinal: string = '';
-  // Check if directory pointed by remoteTaxonomyRepoDir exists and not empty
-  const remoteTaxonomyRepoContainerMountDir = path.join(TAXONOMY_DOCS_CONTAINER_MOUNT_DIR, '/taxonomy');
-  const remoteTaxonomyRepoDir = path.join(TAXONOMY_DOCS_ROOT_DIR, '/taxonomy');
-  if (fs.existsSync(remoteTaxonomyRepoContainerMountDir) && fs.readdirSync(remoteTaxonomyRepoContainerMountDir).length !== 0) {
-    remoteTaxonomyRepoDirFinal = TAXONOMY_DOCS_CONTAINER_MOUNT_DIR;
-  } else {
-    if (fs.existsSync(remoteTaxonomyRepoDir) && fs.readdirSync(remoteTaxonomyRepoDir).length !== 0) {
-      remoteTaxonomyRepoDirFinal = TAXONOMY_DOCS_ROOT_DIR;
-    }
-  }
-  if (remoteTaxonomyRepoDirFinal === '') {
-    return null;
-  }
-
-  const taxonomyDocsDirectoryPath = path.join(remoteTaxonomyRepoDirFinal, '/taxonomy-knowledge-docs');
+  const taxonomyDocsDirectoryPath = path.join(LOCAL_TAXONOMY_DOCS_ROOT_DIR, '/taxonomy-knowledge-docs');
+  console.log(`Cloning taxonomy docs repository to ${taxonomyDocsDirectoryPath}...`);
 
   if (fs.existsSync(taxonomyDocsDirectoryPath)) {
-    console.log(`Using existing taxonomy knowledge docs repository at ${remoteTaxonomyRepoDir}/taxonomy-knowledge-docs.`);
+    console.log(`Using existing taxonomy knowledge docs repository at ${taxonomyDocsDirectoryPath}.`);
     return taxonomyDocsDirectoryPath;
   } else {
     console.log(`Taxonomy knowledge docs repository not found at ${taxonomyDocsDirectoryPath}. Cloning...`);
@@ -104,13 +83,12 @@ async function cloneTaxonomyDocsRepo() {
       http,
       dir: taxonomyDocsDirectoryPath,
       url: TAXONOMY_KNOWLEDGE_DOCS_REPO_URL,
-      singleBranch: true
+      singleBranch: true,
+      depth: 1
     });
 
-    // Include the full path in the response for client display. Path displayed here is the one
-    // that user set in the environment variable.
-    console.log(`Taxonomy knowledge docs repository cloned successfully to ${remoteTaxonomyRepoDir}.`);
-    // Return the path that the UI sees (direct or mounted)
+    // Include the full path in the response for client display
+    console.log(`Repository cloned successfully to ${taxonomyDocsDirectoryPath}.`);
     return taxonomyDocsDirectoryPath;
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';

--- a/src/app/login/githublogin.tsx
+++ b/src/app/login/githublogin.tsx
@@ -142,10 +142,11 @@ const GithubLogin: React.FC = () => {
               <ModalBody id="join-ilab-body-variant">
                 <p>{errorMsg}</p>
               </ModalBody>
-              <ModalFooter >
+              <ModalFooter>
                 <Button key="confirm" variant="primary" onClick={() => sendInvite()}>
                   Send Invite to {githubUsername}
-                </Button>,
+                </Button>
+                ,
                 <Button key="cancel" variant="secondary" onClick={() => handleOnClose()}>
                   No, Thanks
                 </Button>

--- a/src/app/playground/chat/page.tsx
+++ b/src/app/playground/chat/page.tsx
@@ -3,7 +3,25 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import { AppLayout } from '@/components/AppLayout';
-import { Breadcrumb, BreadcrumbItem, PageBreadcrumb, PageSection, Content, Title, MenuToggleElement, MenuToggle, SelectOption, Select, SelectList, Button, Spinner, Form, FormGroup, TextInput, Alert } from '@patternfly/react-core/';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  PageBreadcrumb,
+  PageSection,
+  Content,
+  Title,
+  MenuToggleElement,
+  MenuToggle,
+  SelectOption,
+  Select,
+  SelectList,
+  Button,
+  Spinner,
+  Form,
+  FormGroup,
+  TextInput,
+  Alert
+} from '@patternfly/react-core/';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBroom } from '@fortawesome/free-solid-svg-icons';
 import Image from 'next/image';

--- a/src/app/playground/endpoints/page.tsx
+++ b/src/app/playground/endpoints/page.tsx
@@ -4,7 +4,31 @@ import React, { useState, useEffect } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { AppLayout } from '@/components/AppLayout';
 import { Endpoint } from '@/types';
-import { Breadcrumb, BreadcrumbItem, Button, Content, DataList, DataListAction, DataListCell, DataListItem, DataListItemCells, DataListItemRow, Form, FormGroup, InputGroup, Modal, ModalBody, ModalFooter, ModalHeader, ModalVariant, Page, PageBreadcrumb, PageSection, TextInput, Title } from '@patternfly/react-core';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Button,
+  Content,
+  DataList,
+  DataListAction,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  Form,
+  FormGroup,
+  InputGroup,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+  Page,
+  PageBreadcrumb,
+  PageSection,
+  TextInput,
+  Title
+} from '@patternfly/react-core';
 import { EyeSlashIcon, EyeIcon } from '@patternfly/react-icons';
 
 interface ExtendedEndpoint extends Endpoint {
@@ -101,7 +125,7 @@ const EndpointsPage: React.FC = () => {
     return isApiKeyVisible ? apiKey : '********';
   };
 
-  useEffect(() => { }, [url]);
+  useEffect(() => {}, [url]);
 
   return (
     <AppLayout>
@@ -172,7 +196,6 @@ const EndpointsPage: React.FC = () => {
           >
             <ModalHeader title={currentEndpoint?.id ? 'Edit Endpoint' : 'Add Endpoint'} labelId="endpoint-modal-title" titleIconVariant="info" />
             <ModalBody id="endpoint-body-variant">
-
               <Form>
                 <FormGroup label="URL" isRequired fieldId="url">
                   <TextInput isRequired type="text" id="url" name="url" value={url} onChange={(_, value) => setUrl(value)} placeholder="Enter URL" />
@@ -202,17 +225,17 @@ const EndpointsPage: React.FC = () => {
                   </InputGroup>
                 </FormGroup>
               </Form>
-              </ModalBody>
-              <ModalFooter>
+            </ModalBody>
+            <ModalFooter>
               <Button key="save" variant="primary" onClick={handleSaveEndpoint}>
                 Save
-              </Button>,
+              </Button>
+              ,
               <Button key="cancel" variant="link" onClick={handleModalToggle}>
                 Cancel
               </Button>
-              </ModalFooter>
+            </ModalFooter>
           </Modal>
-
         )}
       </Page>
     </AppLayout>

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -8,7 +8,27 @@ import Link from 'next/link';
 import UserMenu from './UserMenu/UserMenu';
 import { useSession } from 'next-auth/react';
 import { useState } from 'react';
-import { Bullseye, Spinner, Masthead, MastheadMain, MastheadToggle, PageToggleButton, MastheadBrand, Brand, Content, ContentVariants, MastheadContent, NavItem, NavExpandable, Nav, NavList, PageSidebar, PageSidebarBody, SkipToContent, Page } from '@patternfly/react-core';
+import {
+  Bullseye,
+  Spinner,
+  Masthead,
+  MastheadMain,
+  MastheadToggle,
+  PageToggleButton,
+  MastheadBrand,
+  Brand,
+  Content,
+  ContentVariants,
+  MastheadContent,
+  NavItem,
+  NavExpandable,
+  Nav,
+  NavList,
+  PageSidebar,
+  PageSidebarBody,
+  SkipToContent,
+  Page
+} from '@patternfly/react-core';
 import { BarsIcon } from '@patternfly/react-icons';
 
 interface IAppLayout {

--- a/src/components/Contribute/Knowledge/Github/DocumentInformation/DocumentInformation.tsx
+++ b/src/components/Contribute/Knowledge/Github/DocumentInformation/DocumentInformation.tsx
@@ -2,7 +2,25 @@ import React, { useEffect, useState } from 'react';
 import { UploadFile } from '../../UploadFile';
 import { checkKnowledgeFormCompletion } from '../../validation';
 import { KnowledgeFormData } from '@/types';
-import { ValidatedOptions, FormFieldGroupHeader, FormGroup, Button, Modal, ModalVariant, TextInput, FormHelperText, HelperText, HelperTextItem, AlertGroup, Alert, AlertActionCloseButton, AlertActionLink, ModalHeader, ModalBody, ModalFooter } from '@patternfly/react-core';
+import {
+  ValidatedOptions,
+  FormFieldGroupHeader,
+  FormGroup,
+  Button,
+  Modal,
+  ModalVariant,
+  TextInput,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  AlertGroup,
+  Alert,
+  AlertActionCloseButton,
+  AlertActionLink,
+  ModalHeader,
+  ModalBody,
+  ModalFooter
+} from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 interface Props {
@@ -243,10 +261,11 @@ const DocumentInformation: React.FC<Props> = ({
         <ModalBody id="file-upload-switch-body-variant">
           <p>{modalText}</p>
         </ModalBody>
-        <ModalFooter >
+        <ModalFooter>
           <Button key="Continue" variant="secondary" onClick={() => handleModalContinue()}>
             Continue
-          </Button>,
+          </Button>
+          ,
           <Button key="cancel" variant="secondary" onClick={() => setIsModalOpen(false)}>
             Cancel
           </Button>

--- a/src/components/Contribute/Knowledge/Github/index.tsx
+++ b/src/components/Contribute/Knowledge/Github/index.tsx
@@ -22,7 +22,26 @@ import { useRouter } from 'next/navigation';
 import { autoFillKnowledgeFields } from '@/components/Contribute/Knowledge/AutoFill';
 import ReviewSubmission from '@/components/Contribute/Knowledge/ReviewSubmission';
 import { YamlFileUploadModal } from '../../YamlFileUploadModal';
-import { ValidatedOptions, PageGroup, PageBreadcrumb, Breadcrumb, BreadcrumbItem, PageSection, Flex, FlexItem, Title, Button, Content, Wizard, WizardStep, AlertGroup, Alert, AlertActionCloseButton, Spinner, ActionGroup } from '@patternfly/react-core';
+import {
+  ValidatedOptions,
+  PageGroup,
+  PageBreadcrumb,
+  Breadcrumb,
+  BreadcrumbItem,
+  PageSection,
+  Flex,
+  FlexItem,
+  Title,
+  Button,
+  Content,
+  Wizard,
+  WizardStep,
+  AlertGroup,
+  Alert,
+  AlertActionCloseButton,
+  Spinner,
+  ActionGroup
+} from '@patternfly/react-core';
 
 export interface ActionGroupAlertContent {
   title: string;

--- a/src/components/Contribute/Knowledge/Native/DocumentInformation/DocumentInformation.tsx
+++ b/src/components/Contribute/Knowledge/Native/DocumentInformation/DocumentInformation.tsx
@@ -1,8 +1,23 @@
+// src/components/Contribute/Knowledge/Native/DocumentInformation/DocumentInformation.tsx
 import React, { useEffect, useState } from 'react';
 import { UploadFile } from '@/components/Contribute/Knowledge/UploadFile';
 import { checkKnowledgeFormCompletion } from '@/components/Contribute/Knowledge/validation';
 import { KnowledgeFormData } from '@/types';
-import { ValidatedOptions, FormFieldGroupHeader, FormGroup, Button, Modal, ModalVariant, TextInput, FormHelperText, HelperText, HelperTextItem, AlertGroup, Alert, AlertActionCloseButton, AlertActionLink, ModalHeader, ModalBody, ModalFooter } from '@patternfly/react-core';
+import {
+  ValidatedOptions,
+  FormFieldGroupHeader,
+  FormGroup,
+  Button,
+  Modal,
+  ModalVariant,
+  TextInput,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Alert,
+  AlertActionCloseButton,
+  AlertActionLink
+} from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 interface Props {
@@ -10,12 +25,22 @@ interface Props {
   isEditForm?: boolean;
   knowledgeFormData: KnowledgeFormData;
   setDisableAction: React.Dispatch<React.SetStateAction<boolean>>;
+
   knowledgeDocumentRepositoryUrl: string;
   setKnowledgeDocumentRepositoryUrl: React.Dispatch<React.SetStateAction<string>>;
+
   knowledgeDocumentCommit: string;
   setKnowledgeDocumentCommit: React.Dispatch<React.SetStateAction<string>>;
+
   documentName: string;
   setDocumentName: React.Dispatch<React.SetStateAction<string>>;
+}
+
+interface AlertInfo {
+  type: 'success' | 'danger' | 'info';
+  title: string;
+  message: string;
+  link?: string;
 }
 
 const DocumentInformation: React.FC<Props> = ({
@@ -34,17 +59,19 @@ const DocumentInformation: React.FC<Props> = ({
   const [uploadedFiles, setUploadedFiles] = useState<File[]>([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalText, setModalText] = useState<string | undefined>();
-  const [alertInfo, setAlertInfo] = useState<AlertInfo | undefined>();
-  const [validRepo, setValidRepo] = useState<ValidatedOptions>();
-  const [validCommit, setValidCommit] = useState<ValidatedOptions>();
-  const [validDocumentName, setValidDocumentName] = useState<ValidatedOptions>();
 
-  interface AlertInfo {
-    type: 'success' | 'danger' | 'info';
-    title: string;
-    message: string;
-    link?: string;
-  }
+  const [successAlertTitle, setSuccessAlertTitle] = useState<string | undefined>();
+  const [successAlertMessage, setSuccessAlertMessage] = useState<string | undefined>();
+  const [successAlertLink, setSuccessAlertLink] = useState<string | undefined>();
+
+  const [failureAlertTitle, setFailureAlertTitle] = useState<string | undefined>();
+  const [failureAlertMessage, setFailureAlertMessage] = useState<string | undefined>();
+  const [alertInfo, setAlertInfo] = useState<AlertInfo | undefined>();
+
+  const [validRepo, setValidRepo] = useState<ValidatedOptions>(ValidatedOptions.default);
+  const [validCommit, setValidCommit] = useState<ValidatedOptions>(ValidatedOptions.default);
+  const [validDocumentName, setValidDocumentName] = useState<ValidatedOptions>(ValidatedOptions.default);
+
   useEffect(() => {
     setValidRepo(ValidatedOptions.default);
     setValidCommit(ValidatedOptions.default);
@@ -59,25 +86,6 @@ const DocumentInformation: React.FC<Props> = ({
     }
   }, [isEditForm]);
 
-  const validateRepo = (repoStr: string) => {
-    const repo = repoStr.trim();
-    if (repo.length === 0) {
-      setDisableAction(true);
-      setValidRepo(ValidatedOptions.error);
-      return;
-    }
-    try {
-      new URL(repo);
-      setValidRepo(ValidatedOptions.success);
-      setDisableAction(!checkKnowledgeFormCompletion(knowledgeFormData));
-      return;
-    } catch (e) {
-      setDisableAction(true);
-      setValidRepo(ValidatedOptions.warning);
-      return;
-    }
-  };
-
   const validateCommit = (commitStr: string) => {
     const commit = commitStr.trim();
     if (commit.length > 0) {
@@ -91,8 +99,8 @@ const DocumentInformation: React.FC<Props> = ({
   };
 
   const validateDocumentName = (document: string) => {
-    const documentName = document.trim();
-    if (documentName.length > 0) {
+    const documentNameStr = document.trim();
+    if (documentNameStr.length > 0) {
       setValidDocumentName(ValidatedOptions.success);
       setDisableAction(!checkKnowledgeFormCompletion(knowledgeFormData));
       return;
@@ -134,47 +142,49 @@ const DocumentInformation: React.FC<Props> = ({
       );
 
       if (fileContents.length === uploadedFiles.length) {
-        const response = await fetch('/api/native/upload', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({ files: fileContents })
-        });
+        try {
+          const response = await fetch('/api/native/upload', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ files: fileContents })
+          });
 
-        if (!response.ok) {
-          const alertInfo: AlertInfo = {
-            type: 'danger',
-            title: 'Document upload failed!',
-            message: `Upload failed for the added documents. ${response.statusText}`
-          };
-          setAlertInfo(alertInfo);
-          new Error(response.statusText || 'Document upload failed');
-          return;
+          if (response.status === 201) {
+            const result = await response.json();
+            console.log('Files uploaded result:', result);
+
+            setSuccessAlertTitle('Document uploaded successfully!');
+            setSuccessAlertMessage('Documents have been uploaded to your repo to be referenced in the knowledge submission.');
+            if (result.prUrl && result.prUrl.trim() !== '') {
+              setSuccessAlertLink(result.prUrl);
+            } else {
+              setSuccessAlertLink(undefined);
+            }
+          } else {
+            console.error('Upload failed:', response.statusText);
+            setFailureAlertTitle('Failed to upload document');
+            setFailureAlertMessage(`This upload failed. ${response.statusText}`);
+          }
+        } catch (error) {
+          console.error('Upload error:', error);
+          setFailureAlertTitle('Failed to upload document');
+          setFailureAlertMessage(`This upload failed. ${(error as Error).message}`);
         }
-
-        const result = await response.json();
-
-        setKnowledgeDocumentRepositoryUrl(result.repoUrl);
-        setKnowledgeDocumentCommit(result.commitSha);
-        setDocumentName(result.documentNames.join(', ')); // Populate the patterns field
-        console.log('Files uploaded:', result.documentNames);
-
-        const alertInfo: AlertInfo = {
-          type: 'success',
-          title: 'Document uploaded successfully!',
-          message: 'Documents have been uploaded to your repo to be referenced in the knowledge submission.'
-        };
-        if (result.prUrl !== '') {
-          alertInfo.link = result.prUrl;
-        }
-        setAlertInfo(alertInfo);
       }
     }
   };
 
   const onCloseSuccessAlert = () => {
-    setAlertInfo(undefined);
+    setSuccessAlertTitle(undefined);
+    setSuccessAlertMessage(undefined);
+    setSuccessAlertLink(undefined);
+  };
+
+  const onCloseFailureAlert = () => {
+    setFailureAlertTitle(undefined);
+    setFailureAlertMessage(undefined);
   };
 
   const handleAutomaticUpload = () => {
@@ -199,6 +209,7 @@ const DocumentInformation: React.FC<Props> = ({
     if (useFileUpload) {
       setUploadedFiles([]);
     } else {
+      console.log('Switching to manual entry - clearing repository and document info');
       setKnowledgeDocumentRepositoryUrl('');
       setValidRepo(ValidatedOptions.default);
       setKnowledgeDocumentCommit('');
@@ -212,20 +223,30 @@ const DocumentInformation: React.FC<Props> = ({
 
   return (
     <div>
-      <FormFieldGroupHeader titleDescription="Add the relevant document's information: " />
+      <FormFieldGroupHeader
+        titleText={{
+          text: (
+            <p>
+              Document Information <span style={{ color: 'red' }}>*</span>
+            </p>
+          ),
+          id: 'doc-info-id'
+        }}
+        titleDescription="Add the relevant document's information"
+      />
       <FormGroup>
         <div style={{ display: 'flex', gap: '10px' }}>
           <Button
             variant={useFileUpload ? 'primary' : 'secondary'}
             className={useFileUpload ? 'button-active' : 'button-secondary'}
-            onClick={() => handleAutomaticUpload()}
+            onClick={handleAutomaticUpload}
           >
             Automatically Upload Documents
           </Button>
           <Button
             variant={useFileUpload ? 'secondary' : 'primary'}
             className={!useFileUpload ? 'button-active' : 'button-secondary'}
-            onClick={() => handleManualUpload()}
+            onClick={handleManualUpload}
           >
             Manually Enter Document Details
           </Button>
@@ -234,63 +255,39 @@ const DocumentInformation: React.FC<Props> = ({
       <Modal
         variant={ModalVariant.medium}
         title="Data Loss Warning"
+        titleIconVariant="warning"
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
-        aria-labelledby="file-upload-switch-modal-title"
-        aria-describedby="file-upload-switch-body-variant"
-      >
-        <ModalHeader title="Data Loss Warning" labelId="file-upload-switch-modal-title" titleIconVariant="warning" />
-        <ModalBody id="file-upload-switch-body-variant">
-          <p>{modalText}</p>
-        </ModalBody>
-        <ModalFooter >
-          <Button key="Continue" variant="secondary" onClick={() => handleModalContinue()}>
+        actions={[
+          <Button key="Continue" variant="secondary" onClick={handleModalContinue}>
             Continue
           </Button>,
           <Button key="cancel" variant="secondary" onClick={() => setIsModalOpen(false)}>
             Cancel
           </Button>
-        </ModalFooter>
+        ]}
+      >
+        <p>{modalText}</p>
       </Modal>
-
       {!useFileUpload ? (
         <>
-          <FormGroup isRequired key={'doc-info-details-id'} label="Repo URL">
+          <FormGroup isRequired key={'doc-info-details-id'} label="Repo URL or File Path">
             <TextInput
               isRequired
               type="url"
               aria-label="repo"
               validated={validRepo}
-              placeholder="Enter repo url where document exists"
+              placeholder="Enter repo URL where document exists"
               value={knowledgeDocumentRepositoryUrl}
               onChange={(_event, value) => setKnowledgeDocumentRepositoryUrl(value)}
-              onBlur={() => validateRepo(knowledgeDocumentRepositoryUrl)}
             />
-            {validRepo === ValidatedOptions.error && (
-              <FormHelperText>
-                <HelperText>
-                  <HelperTextItem icon={<ExclamationCircleIcon />} variant={validRepo}>
-                    Required field
-                  </HelperTextItem>
-                </HelperText>
-              </FormHelperText>
-            )}
-            {validRepo === ValidatedOptions.warning && (
-              <FormHelperText>
-                <HelperText>
-                  <HelperTextItem icon={<ExclamationCircleIcon />} variant="error">
-                    Please enter a valid URL.
-                  </HelperTextItem>
-                </HelperText>
-              </FormHelperText>
-            )}
           </FormGroup>
           <FormGroup isRequired key={'doc-info-details-commit_sha'} label="Commit SHA">
             <TextInput
               isRequired
               type="text"
               aria-label="commit"
-              placeholder="Enter the commit sha of the document in that repo"
+              placeholder="Enter the commit SHA of the document in that repo"
               value={knowledgeDocumentCommit}
               validated={validCommit}
               onChange={(_event, value) => setKnowledgeDocumentCommit(value)}
@@ -311,7 +308,7 @@ const DocumentInformation: React.FC<Props> = ({
               isRequired
               type="text"
               aria-label="patterns"
-              placeholder="Enter the documents name (comma separated)"
+              placeholder="Enter the document names (comma separated)"
               value={documentName}
               validated={validDocumentName}
               onChange={(_event, value) => setDocumentName(value)}
@@ -331,31 +328,47 @@ const DocumentInformation: React.FC<Props> = ({
       ) : (
         <>
           <UploadFile onFilesChange={handleFilesChange} />
-          <Button variant="primary" onClick={handleDocumentUpload}>
+          <Button variant="primary" onClick={handleDocumentUpload} isDisabled={uploadedFiles.length === 0}>
             Submit Files
           </Button>
         </>
       )}
 
+      {/* Informational Alert */}
       {alertInfo && (
-        <AlertGroup isToast isLiveRegion>
-          <Alert
-            variant={alertInfo.type}
-            title={alertInfo.title}
-            actionClose={<AlertActionCloseButton onClose={onCloseSuccessAlert} />}
-            actionLinks={
-              alertInfo.link && (
-                <>
-                  <AlertActionLink component="a" href={alertInfo.link} rel="noopener noreferrer">
-                    View it here
-                  </AlertActionLink>
-                </>
-              )
-            }
-          >
-            {alertInfo.message}
-          </Alert>
-        </AlertGroup>
+        <Alert variant={alertInfo.type} title={alertInfo.title} actionClose={<AlertActionCloseButton onClose={() => setAlertInfo(undefined)} />}>
+          {alertInfo.message}
+          {alertInfo.link && (
+            <AlertActionLink href={alertInfo.link} target="_blank" rel="noopener noreferrer">
+              View it here
+            </AlertActionLink>
+          )}
+        </Alert>
+      )}
+
+      {/* Success Alert */}
+      {successAlertTitle && successAlertMessage && (
+        <Alert
+          variant="success"
+          title={successAlertTitle}
+          actionClose={<AlertActionCloseButton onClose={onCloseSuccessAlert} />}
+          actionLinks={
+            successAlertLink ? (
+              <AlertActionLink component="a" href={successAlertLink} target="_blank" rel="noopener noreferrer">
+                View it here
+              </AlertActionLink>
+            ) : null
+          }
+        >
+          {successAlertMessage}
+        </Alert>
+      )}
+
+      {/* Failure Alert */}
+      {failureAlertTitle && failureAlertMessage && (
+        <Alert variant="danger" title={failureAlertTitle} actionClose={<AlertActionCloseButton onClose={onCloseFailureAlert} />}>
+          {failureAlertMessage}
+        </Alert>
       )}
     </div>
   );

--- a/src/components/Contribute/Knowledge/Native/DocumentInformation/DocumentInformation.tsx
+++ b/src/components/Contribute/Knowledge/Native/DocumentInformation/DocumentInformation.tsx
@@ -252,26 +252,20 @@ const DocumentInformation: React.FC<Props> = ({
           </Button>
         </div>
       </FormGroup>
-      <Modal
-        variant={ModalVariant.medium}
-        title="Data Loss Warning"
-        titleIconVariant="warning"
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        actions={[
-          <Button key="Continue" variant="secondary" onClick={handleModalContinue}>
+      <Modal variant={ModalVariant.medium} title="Data Loss Warning" isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
+        <p>{modalText}</p>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px', marginTop: '20px' }}>
+          <Button variant="secondary" onClick={handleModalContinue}>
             Continue
-          </Button>,
-          <Button key="cancel" variant="secondary" onClick={() => setIsModalOpen(false)}>
+          </Button>
+          <Button variant="secondary" onClick={() => setIsModalOpen(false)}>
             Cancel
           </Button>
-        ]}
-      >
-        <p>{modalText}</p>
+        </div>
       </Modal>
       {!useFileUpload ? (
         <>
-          <FormGroup isRequired key={'doc-info-details-id'} label="Repo URL or File Path">
+          <FormGroup isRequired key={'doc-info-details-id'} label="Repo URL or Server Side File Path">
             <TextInput
               isRequired
               type="url"

--- a/src/components/Contribute/Knowledge/Native/KnowledgeQuestionAnswerPairsNative/KnowledgeQuestionAnswerPairs.tsx
+++ b/src/components/Contribute/Knowledge/Native/KnowledgeQuestionAnswerPairsNative/KnowledgeQuestionAnswerPairs.tsx
@@ -259,8 +259,17 @@ const KnowledgeQuestionAnswerPairsNative: React.FC<Props> = ({
               color: '#333'
             }}
           >
-            A commit SHA (<strong>{commitSha}</strong>) has already been selected in a previous seed example. All subsequent selections must use the
-            same commit SHA for consistency.
+            <Alert
+              variant="warning"
+              isInline
+              title="All knowledge files need to originate from the same commit or 'Document Information' submission"
+              style={{ marginBottom: '20px' }}
+            >
+              A commit SHA (<strong>{commitSha}</strong>) has already been selected in a previous seed example. All subsequent selections must use the
+              same commit SHA for consistency.
+            </Alert>
+            {/*A commit SHA (<strong>{commitSha}</strong>) has already been selected in a previous seed example. All subsequent selections must use the*/}
+            {/*same commit SHA for consistency.*/}
           </div>
         )}
 

--- a/src/components/Contribute/Knowledge/Native/KnowledgeQuestionAnswerPairsNative/KnowledgeQuestionAnswerPairs.tsx
+++ b/src/components/Contribute/Knowledge/Native/KnowledgeQuestionAnswerPairsNative/KnowledgeQuestionAnswerPairs.tsx
@@ -1,0 +1,448 @@
+// src/components/Contribute/Knowledge/KnowledgeQuestionAnswerPairs/KnowledgeQuestionAnswerPairs.tsx
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { FormFieldGroupHeader, FormGroup, FormHelperText } from '@patternfly/react-core/dist/dynamic/components/Form';
+import { TextArea } from '@patternfly/react-core/dist/dynamic/components/TextArea';
+import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/dynamic/icons/';
+import { ValidatedOptions } from '@patternfly/react-core/dist/esm/helpers/constants';
+import { HelperText } from '@patternfly/react-core/dist/dynamic/components/HelperText';
+import { HelperTextItem } from '@patternfly/react-core/dist/dynamic/components/HelperText';
+import { KnowledgeSeedExample, QuestionAndAnswerPair } from '@/types';
+import { Modal, ModalVariant } from '@patternfly/react-core/dist/dynamic/components/Modal';
+import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
+import { CatalogIcon } from '@patternfly/react-icons/dist/esm/icons/catalog-icon';
+import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
+import { Spinner } from '@patternfly/react-core/dist/dynamic/components/Spinner';
+import { ExpandableSection } from '@patternfly/react-core/dist/esm/components/ExpandableSection/ExpandableSection';
+import { Content } from '@patternfly/react-core/dist/dynamic/components/Content';
+import { Switch } from '@patternfly/react-core/dist/dynamic/components/Switch';
+import { Card, CardBody, CardHeader } from '@patternfly/react-core/dist/dynamic/components/Card';
+import { Stack, StackItem } from '@patternfly/react-core/dist/dynamic/layouts/Stack';
+import { Alert } from '@patternfly/react-core/dist/dynamic/components/Alert';
+
+interface KnowledgeFile {
+  filename: string;
+  content: string;
+  commitSha: string;
+  commitDate?: string;
+}
+
+interface Props {
+  seedExample: KnowledgeSeedExample;
+  seedExampleIndex: number;
+  handleContextInputChange: (seedExampleIndex: number, contextValue: string) => void;
+  handleContextBlur: (seedExampleIndex: number) => void;
+  handleQuestionInputChange: (seedExampleIndex: number, questionAndAnswerIndex: number, questionValue: string) => void;
+  handleQuestionBlur: (seedExampleIndex: number, questionAndAnswerIndex: number) => void;
+  handleAnswerInputChange: (seedExampleIndex: number, questionAndAnswerIndex: number, answerValue: string) => void;
+  handleAnswerBlur: (seedExampleIndex: number, questionAndAnswerIndex: number) => void;
+  addDocumentInfo: (repositoryUrl: string, commitSha: string, docName: string) => void;
+  repositoryUrl: string;
+  commitSha: string;
+}
+
+const KnowledgeQuestionAnswerPairsNative: React.FC<Props> = ({
+  seedExample,
+  seedExampleIndex,
+  handleContextInputChange,
+  handleContextBlur,
+  handleQuestionInputChange,
+  handleQuestionBlur,
+  handleAnswerInputChange,
+  handleAnswerBlur,
+  addDocumentInfo,
+  repositoryUrl,
+  commitSha
+}) => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [knowledgeFiles, setKnowledgeFiles] = useState<KnowledgeFile[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string>('');
+  const [expandedFiles, setExpandedFiles] = useState<Record<string, boolean>>({});
+  const [selectedWordCount, setSelectedWordCount] = useState<number>(0);
+  const [showAllCommits, setShowAllCommits] = useState<boolean>(false);
+
+  // Ref for the <pre> elements to track selections TODO: figure out how to make text expansions taller in PF without a custom-pre
+  const preRefs = useRef<Record<string, HTMLPreElement | null>>({});
+
+  const LOCAL_TAXONOMY_DOCS_ROOT_DIR =
+    process.env.NEXT_PUBLIC_LOCAL_TAXONOMY_DOCS_ROOT_DIR || '/home/yourusername/.instructlab-ui/taxonomy-knowledge-docs';
+
+  const fetchKnowledgeFiles = async () => {
+    setIsLoading(true);
+    setError('');
+    try {
+      const response = await fetch('/api/native/git/knowledge-files', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ branchName: 'main', action: 'diff' })
+      });
+
+      const result = await response.json();
+      if (response.ok) {
+        setKnowledgeFiles(result.files);
+        console.log('Fetched knowledge files:', result.files);
+      } else {
+        setError(result.error || 'Failed to fetch knowledge files.');
+        console.error('Error fetching knowledge files:', result.error);
+      }
+    } catch (err) {
+      setError('An error occurred while fetching knowledge files.');
+      console.error('Error fetching knowledge files:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleOpenModal = () => {
+    setIsModalOpen(true);
+    fetchKnowledgeFiles();
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setKnowledgeFiles([]);
+    setError('');
+    setSelectedWordCount(0);
+    setShowAllCommits(false);
+    window.getSelection()?.removeAllRanges();
+  };
+
+  const handleUseSelectedText = (file: KnowledgeFile) => {
+    const selection = window.getSelection();
+    const selectedText = selection?.toString().trim();
+
+    if (!selectedText) {
+      alert('Please select the text you want to use as context.');
+      return;
+    }
+
+    repositoryUrl = `${LOCAL_TAXONOMY_DOCS_ROOT_DIR}/${file.filename}`;
+    const commitShaValue = file.commitSha;
+    const docName = file.filename;
+
+    console.log(
+      `handleUseSelectedText: selectedText="${selectedText}", repositoryUrl=${repositoryUrl}, commitSha=${commitShaValue}, docName=${docName}`
+    );
+
+    handleContextInputChange(seedExampleIndex, selectedText);
+    handleContextBlur(seedExampleIndex);
+    addDocumentInfo(repositoryUrl, commitShaValue, docName);
+    handleCloseModal();
+  };
+
+  const updateSelectedWordCount = (filename: string) => {
+    const selection = window.getSelection();
+    const preElement = preRefs.current[filename];
+    if (selection && preElement) {
+      const anchorNode = selection.anchorNode;
+      const focusNode = selection.focusNode;
+
+      if (preElement.contains(anchorNode) && preElement.contains(focusNode)) {
+        const selectedText = selection.toString().trim();
+        const wordCount = selectedText.split(/\s+/).filter((word) => word.length > 0).length;
+        setSelectedWordCount(wordCount);
+      } else {
+        setSelectedWordCount(0);
+      }
+    }
+  };
+
+  // Attach event listeners for selection changes
+  useEffect(() => {
+    if (isModalOpen) {
+      const handleSelectionChange = () => {
+        // Iterate through all expanded files and update word count
+        Object.keys(expandedFiles).forEach((filename) => {
+          if (expandedFiles[filename]) {
+            updateSelectedWordCount(filename);
+          }
+        });
+      };
+      document.addEventListener('selectionchange', handleSelectionChange);
+      return () => {
+        document.removeEventListener('selectionchange', handleSelectionChange);
+      };
+    } else {
+      setSelectedWordCount(0);
+    }
+  }, [isModalOpen, expandedFiles]);
+
+  const toggleFileContent = (filename: string) => {
+    setExpandedFiles((prev) => ({
+      ...prev,
+      [filename]: !prev[filename]
+    }));
+    console.log(`toggleFileContent: filename=${filename}, expanded=${!expandedFiles[filename]}`);
+  };
+
+  // Group files by commitSha
+  const groupedFiles = knowledgeFiles.reduce<Record<string, KnowledgeFile[]>>((acc, file) => {
+    if (!acc[file.commitSha]) {
+      acc[file.commitSha] = [];
+    }
+    acc[file.commitSha].push(file);
+    return acc;
+  }, {});
+
+  // Extract commit dates for sorting
+  const commitDateMap: Record<string, string> = {};
+  knowledgeFiles.forEach((file) => {
+    if (file.commitDate && !commitDateMap[file.commitSha]) {
+      commitDateMap[file.commitSha] = file.commitDate;
+    }
+  });
+
+  // Sort the commit SHAs based on commitDate in descending order (latest first)
+  const sortedCommitShas = Object.keys(groupedFiles).sort((a, b) => {
+    const dateA = new Date(commitDateMap[a] || '').getTime();
+    const dateB = new Date(commitDateMap[b] || '').getTime();
+    return dateB - dateA;
+  });
+
+  // Enforce single commit SHA and repository URL
+  const isSameCommit = (fileCommitSha: string): boolean => {
+    if (!commitSha) {
+      return true;
+    }
+    return fileCommitSha === commitSha;
+  };
+
+  // Determine which commits to display based on the toggle
+  const commitsToDisplay = showAllCommits ? sortedCommitShas : sortedCommitShas.slice(0, 1);
+
+  const setPreRef = useCallback(
+    (filename: string) => (el: HTMLPreElement | null) => {
+      preRefs.current[filename] = el;
+    },
+    []
+  );
+
+  return (
+    <FormGroup style={{ padding: '20px' }}>
+      <Tooltip content={<div>Select context from your knowledge files</div>} position="top">
+        <Button variant="secondary" onClick={handleOpenModal} style={{ marginBottom: '10px' }}>
+          <CatalogIcon /> Select Context from Files
+        </Button>
+      </Tooltip>
+
+      <TextArea
+        isRequired
+        type="text"
+        aria-label={`Context ${seedExampleIndex + 1}`}
+        placeholder="Enter the context from which the Q&A pairs are derived. (500 words max)"
+        value={seedExample.context}
+        validated={seedExample.isContextValid}
+        maxLength={500}
+        style={{ marginBottom: '20px' }}
+        onChange={(_event, contextValue: string) => handleContextInputChange(seedExampleIndex, contextValue)}
+        onBlur={() => handleContextBlur(seedExampleIndex)}
+      />
+      {seedExample.isContextValid === ValidatedOptions.error && (
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem icon={<ExclamationCircleIcon />} variant={seedExample.isContextValid}>
+              {seedExample.validationError || 'Required field. It must be non-empty and less than 500 words.'}
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      )}
+
+      <Modal variant={ModalVariant.large} title="Select a Knowledge File" isOpen={isModalOpen} onClose={handleCloseModal} style={{ padding: '20px' }}>
+        {commitSha && (
+          <div
+            style={{
+              padding: '10px',
+              backgroundColor: '#f2f2f2',
+              borderRadius: '5px',
+              marginBottom: '10px',
+              fontSize: '14px',
+              color: '#333'
+            }}
+          >
+            A commit SHA (<strong>{commitSha}</strong>) has already been selected in a previous seed example. All subsequent selections must use the
+            same commit SHA for consistency.
+          </div>
+        )}
+
+        <Alert variant="info" isInline title="Instructions" style={{ marginBottom: '20px' }}>
+          Please highlight up to 500 words and click the &quot;Use Selected Text For Context&quot; button to populate the context field. Knowledge
+          context must be verbatim from the knowledge file by selecting the text. Multiple files can be used for context selection, but they must
+          belong to the same commit (SHA).
+        </Alert>
+        <div style={{ marginBottom: '20px' }}>
+          <Switch
+            label="Show All Knowledge Files"
+            // labelOff="Show Only Most Recent Commit"
+            isChecked={showAllCommits}
+            onChange={() => setShowAllCommits(!showAllCommits)}
+            id="show-all-commits-toggle"
+          />
+        </div>
+
+        {isLoading && (
+          <div style={{ display: 'flex', alignItems: 'center', padding: '10px', gap: '10px' }}>
+            <Spinner size="md" />
+            <span>Loading knowledge files and their commits...</span>
+          </div>
+        )}
+        {!isLoading && error && <div style={{ color: 'red', padding: '10px' }}>{error}</div>}
+        {!isLoading && !error && knowledgeFiles.length === 0 && <div style={{ padding: '10px' }}>No knowledge files available.</div>}
+        {!isLoading && !error && knowledgeFiles.length > 0 && (
+          <Stack hasGutter style={{ padding: '10px' }}>
+            {commitsToDisplay.map((commitShaKey) => {
+              const files = groupedFiles[commitShaKey];
+              const isSelectable = isSameCommit(commitShaKey);
+              const commitDate = commitDateMap[commitShaKey];
+              const formattedDate = commitDate ? new Date(commitDate).toLocaleString() : 'Unknown date';
+
+              // Highlight the card if commitShaKey matches currently selected commitSha
+              const highlightCard = commitSha && commitShaKey === commitSha;
+
+              return (
+                <StackItem key={commitShaKey}>
+                  <Card
+                    style={{
+                      boxShadow: '0 4px 8px rgba(0,0,0,0.1)',
+                      borderRadius: '8px',
+                      padding: '15px',
+                      border: highlightCard ? '2px solid #007BFF' : '1px solid #ccc',
+                      backgroundColor: highlightCard ? '#FFF' : '#fff'
+                    }}
+                  >
+                    <CardHeader>
+                      <strong>Commit SHA:</strong> {commitShaKey} <br />
+                      <strong>Date:</strong> {formattedDate}
+                    </CardHeader>
+                    <CardBody style={{ padding: '15px' }}>
+                      {files.map((file) => (
+                        <div key={file.filename} style={{ marginBottom: '10px' }}>
+                          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                            <div style={{ marginRight: '10px', fontWeight: 'bold' }}>{file.filename}</div>
+                            <div>
+                              <Button
+                                variant="link"
+                                onClick={() => toggleFileContent(file.filename)}
+                                isDisabled={!isSelectable}
+                                style={{ marginRight: '10px' }}
+                              >
+                                {expandedFiles[file.filename] ? 'Hide' : 'Show'} Contents for Context Selection
+                              </Button>
+                            </div>
+                          </div>
+                          {expandedFiles[file.filename] && (
+                            <ExpandableSection
+                              toggleText={expandedFiles[file.filename] ? 'Hide file contents' : 'Show file contents'}
+                              onToggle={() => toggleFileContent(file.filename)}
+                              isExpanded={expandedFiles[file.filename]}
+                              style={{ marginTop: '10px' }}
+                            >
+                              <pre
+                                ref={setPreRef(file.filename)}
+                                style={{
+                                  whiteSpace: 'pre-wrap',
+                                  wordBreak: 'break-word',
+                                  backgroundColor: '#f5f5f5',
+                                  padding: '10px',
+                                  borderRadius: '4px',
+                                  maxHeight: '700px',
+                                  overflowY: 'auto',
+                                  userSelect: 'text'
+                                }}
+                              >
+                                {file.content}
+                              </pre>
+                              <div style={{ display: 'flex', alignItems: 'center', marginTop: '10px' }}>
+                                <Button
+                                  variant="primary"
+                                  onClick={() => handleUseSelectedText(file)}
+                                  isDisabled={selectedWordCount === 0 || selectedWordCount > 500} // Disable if word count exceeds 500
+                                  style={{ marginRight: '10px' }}
+                                >
+                                  Use Selected Text For Context
+                                </Button>
+                                <Content
+                                  component="small"
+                                  style={{
+                                    fontWeight: 'bold',
+                                    color: selectedWordCount > 500 ? 'red' : 'green'
+                                  }}
+                                >
+                                  {selectedWordCount}/500 words selected
+                                </Content>
+                              </div>
+                            </ExpandableSection>
+                          )}
+                        </div>
+                      ))}
+                    </CardBody>
+                  </Card>
+                </StackItem>
+              );
+            })}
+          </Stack>
+        )}
+      </Modal>
+
+      {seedExample.questionAndAnswers.map((questionAndAnswerPair: QuestionAndAnswerPair, questionAnswerIndex) => (
+        <div key={seedExampleIndex * 100 + questionAnswerIndex * 10 + 0}>
+          <FormFieldGroupHeader
+            titleText={{
+              text: (
+                <p>
+                  Q&A Pair {questionAnswerIndex + 1} {questionAndAnswerPair.immutable && <span style={{ color: 'red' }}>*</span>}
+                </p>
+              ),
+              id: 'nested-field-group1-titleText-id'
+            }}
+          />
+          <React.Fragment>
+            <TextArea
+              isRequired
+              type="text"
+              aria-label={`Question ${seedExampleIndex + 1}-${questionAnswerIndex + 1}`}
+              placeholder={`Enter question ${questionAnswerIndex + 1}`}
+              value={questionAndAnswerPair.question}
+              maxLength={250}
+              validated={questionAndAnswerPair.isQuestionValid}
+              style={{ marginBottom: '10px' }}
+              onChange={(_event, questionValue) => handleQuestionInputChange(seedExampleIndex, questionAnswerIndex, questionValue)}
+              onBlur={() => handleQuestionBlur(seedExampleIndex, questionAnswerIndex)}
+            />
+            {questionAndAnswerPair.isQuestionValid === ValidatedOptions.error && (
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem icon={<ExclamationCircleIcon />} variant={questionAndAnswerPair.isQuestionValid}>
+                    {questionAndAnswerPair.questionValidationError || 'Required field. Total length of all Q&A pairs should be less than 250 words.'}
+                  </HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            )}
+            <TextArea
+              isRequired
+              type="text"
+              aria-label={`Answer ${seedExampleIndex + 1}-${questionAnswerIndex + 1}`}
+              placeholder={`Enter answer ${questionAnswerIndex + 1}`}
+              value={questionAndAnswerPair.answer}
+              maxLength={250}
+              validated={questionAndAnswerPair.isAnswerValid}
+              style={{ marginTop: '10px' }}
+              onChange={(_event, answerValue) => handleAnswerInputChange(seedExampleIndex, questionAnswerIndex, answerValue)}
+              onBlur={() => handleAnswerBlur(seedExampleIndex, questionAnswerIndex)}
+            />
+            {questionAndAnswerPair.isAnswerValid === ValidatedOptions.error && (
+              <FormHelperText style={{ marginTop: '5px' }}>
+                <HelperText>
+                  <HelperTextItem icon={<ExclamationCircleIcon />} variant={questionAndAnswerPair.isAnswerValid}>
+                    {questionAndAnswerPair.answerValidationError || 'Required field. Total length of all Q&A pairs should be less than 250 words.'}
+                  </HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            )}
+          </React.Fragment>
+        </div>
+      ))}
+    </FormGroup>
+  );
+};
+
+export default KnowledgeQuestionAnswerPairsNative;

--- a/src/components/Contribute/Knowledge/Native/KnowledgeSeedExampleNative/KnowledgeSeedExampleNative.tsx
+++ b/src/components/Contribute/Knowledge/Native/KnowledgeSeedExampleNative/KnowledgeSeedExampleNative.tsx
@@ -1,0 +1,87 @@
+// src/components/Contribute/Knowledge/Native/KnowledgeSeedExampleNative/KnowledgeQuestionAnswerPairsNative.tsx
+import React from 'react';
+import { Accordion, AccordionItem, AccordionContent, AccordionToggle } from '@patternfly/react-core/dist/dynamic/components/Accordion';
+import { FormFieldGroupHeader } from '@patternfly/react-core/dist/dynamic/components/Form';
+import KnowledgeQuestionAnswerPairsNative from '../KnowledgeQuestionAnswerPairsNative/KnowledgeQuestionAnswerPairs';
+import type { KnowledgeSeedExample } from '@/types';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+
+interface Props {
+  seedExamples: KnowledgeSeedExample[];
+  handleContextInputChange: (seedExampleIndex: number, contextValue: string) => void;
+  handleContextBlur: (seedExampleIndex: number) => void;
+  handleQuestionInputChange: (seedExampleIndex: number, questionAndAnswerIndex: number, questionValue: string) => void;
+  handleQuestionBlur: (seedExampleIndex: number, questionAndAnswerIndex: number) => void;
+  handleAnswerInputChange: (seedExampleIndex: number, questionAndAnswerIndex: number, answerValue: string) => void;
+  handleAnswerBlur: (seedExampleIndex: number, questionAndAnswerIndex: number) => void;
+  toggleSeedExampleExpansion?: (index: number) => void;
+  addDocumentInfo: (repoUrl: string, commitSha: string, docName: string) => void;
+  repositoryUrl: string;
+  commitSha: string;
+}
+
+const KnowledgeSeedExampleNative: React.FC<Props> = ({
+  seedExamples,
+  handleContextInputChange,
+  handleContextBlur,
+  handleQuestionInputChange,
+  handleQuestionBlur,
+  handleAnswerInputChange,
+  handleAnswerBlur,
+  toggleSeedExampleExpansion = () => {},
+  addDocumentInfo,
+  repositoryUrl,
+  commitSha
+}) => {
+  return (
+    <div>
+      <FormFieldGroupHeader
+        titleText={{
+          text: (
+            <p>
+              Seed Examples <span style={{ color: 'red' }}>*</span>
+            </p>
+          ),
+          id: 'seed-examples-id'
+        }}
+        titleDescription={
+          <p>
+            Add seed examples with context and minimum 3 question and answer pairs. A minimum of five seed examples are required.{' '}
+            <a href="https://docs.instructlab.ai/taxonomy/knowledge/#knowledge-yaml-examples" target="_blank" rel="noopener noreferrer">
+              {' '}
+              Learn more about seed examples
+              <ExternalLinkAltIcon style={{ padding: '3px' }}></ExternalLinkAltIcon>
+            </a>
+          </p>
+        }
+      />
+
+      <Accordion asDefinitionList={false}>
+        {seedExamples.map((seedExample: KnowledgeSeedExample, seedExampleIndex: number) => (
+          <AccordionItem key={seedExampleIndex} isExpanded={seedExample.isExpanded}>
+            <AccordionToggle onClick={() => toggleSeedExampleExpansion(seedExampleIndex)} id={`seed-example-toggle-${seedExampleIndex}`}>
+              Seed Example {seedExampleIndex + 1} {seedExample.immutable && <span style={{ color: 'red' }}>*</span>}
+            </AccordionToggle>
+            <AccordionContent id={`seed-example-content-${seedExampleIndex}`}>
+              <KnowledgeQuestionAnswerPairsNative
+                seedExample={seedExample}
+                seedExampleIndex={seedExampleIndex}
+                handleContextInputChange={handleContextInputChange}
+                handleContextBlur={handleContextBlur}
+                handleQuestionInputChange={handleQuestionInputChange}
+                handleQuestionBlur={handleQuestionBlur}
+                handleAnswerInputChange={handleAnswerInputChange}
+                handleAnswerBlur={handleAnswerBlur}
+                addDocumentInfo={addDocumentInfo}
+                repositoryUrl={repositoryUrl}
+                commitSha={commitSha}
+              />
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </div>
+  );
+};
+
+export default KnowledgeSeedExampleNative;

--- a/src/components/Contribute/Knowledge/Native/index.tsx
+++ b/src/components/Contribute/Knowledge/Native/index.tsx
@@ -12,17 +12,36 @@ import DocumentInformation from '@/components/Contribute/Knowledge/Native/Docume
 import AttributionInformation from '@/components/Contribute/Knowledge/AttributionInformation/AttributionInformation';
 import Submit from './Submit/Submit';
 import KnowledgeDescriptionContent from '@/components/Contribute/Knowledge/KnowledgeDescription/KnowledgeDescriptionContent';
-import KnowledgeSeedExample from '@/components/Contribute/Knowledge/KnowledgeSeedExample/KnowledgeSeedExample';
+import KnowledgeSeedExampleNative from '@/components/Contribute/Knowledge/Native/KnowledgeSeedExampleNative/KnowledgeSeedExampleNative';
 import { checkKnowledgeFormCompletion } from '@/components/Contribute/Knowledge/validation';
 import { DownloadDropdown } from '@/components/Contribute/Knowledge/DownloadDropdown/DownloadDropdown';
 import { ViewDropdown } from '@/components/Contribute/Knowledge/ViewDropdown/ViewDropdown';
 import Update from '@/components/Contribute/Knowledge/Github/Update/Update';
-import { KnowledgeEditFormData, KnowledgeFormData, KnowledgeYamlData, QuestionAndAnswerPair } from '@/types';
+import { KnowledgeEditFormData, KnowledgeFormData, KnowledgeSeedExample, KnowledgeYamlData, QuestionAndAnswerPair } from '@/types';
 import { useRouter } from 'next/navigation';
 import { autoFillKnowledgeFields } from '@/components/Contribute/Knowledge/AutoFill';
 import ReviewSubmission from '../ReviewSubmission';
 import { YamlFileUploadModal } from '../../YamlFileUploadModal';
-import { ValidatedOptions, PageGroup, PageBreadcrumb, Breadcrumb, BreadcrumbItem, PageSection, Flex, FlexItem, Title, Button, Content, Wizard, WizardStep, AlertGroup, Alert, AlertActionCloseButton, Spinner, ActionGroup } from '@patternfly/react-core';
+import {
+  ValidatedOptions,
+  PageGroup,
+  PageBreadcrumb,
+  Breadcrumb,
+  BreadcrumbItem,
+  PageSection,
+  Flex,
+  FlexItem,
+  Title,
+  Button,
+  Content,
+  Wizard,
+  WizardStep,
+  AlertGroup,
+  Alert,
+  AlertActionCloseButton,
+  Spinner,
+  ActionGroup
+} from '@patternfly/react-core';
 
 export interface ActionGroupAlertContent {
   title: string;
@@ -54,10 +73,10 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
   // File Path Information
   const [filePath, setFilePath] = useState<string>('');
 
+  // Document Information (using fields from KnowledgeFormData)
   const [knowledgeDocumentRepositoryUrl, setKnowledgeDocumentRepositoryUrl] = useState<string>('');
   const [knowledgeDocumentCommit, setKnowledgeDocumentCommit] = useState<string>('');
-  // This used to be 'patterns' but I am not totally sure what this variable actually is...
-  const [documentName, setDocumentName] = useState<string>('');
+  const [documentName, setDocumentName] = useState<string>(''); // store as comma-separated
 
   // Attribution Information
   // State
@@ -71,48 +90,57 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
 
   const [disableAction, setDisableAction] = useState<boolean>(true);
   const [reset, setReset] = useState<boolean>(false);
-  const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const [isYamlModalOpen, setIsYamlModalOpen] = useState<boolean>(false); // **New State Added**
 
   const router = useRouter();
 
   const [activeStepIndex] = useState<number>(1);
 
-  const emptySeedExample: KnowledgeSeedExample = {
+  // Function to create a unique empty seed example
+  const createEmptySeedExample = (): KnowledgeSeedExample => ({
     immutable: true,
     isExpanded: false,
     context: '',
     isContextValid: ValidatedOptions.default,
+    validationError: '',
     questionAndAnswers: [
       {
         immutable: true,
         question: '',
         isQuestionValid: ValidatedOptions.default,
+        questionValidationError: '',
         answer: '',
-        isAnswerValid: ValidatedOptions.default
+        isAnswerValid: ValidatedOptions.default,
+        answerValidationError: ''
       },
       {
         immutable: true,
         question: '',
         isQuestionValid: ValidatedOptions.default,
+        questionValidationError: '',
         answer: '',
-        isAnswerValid: ValidatedOptions.default
+        isAnswerValid: ValidatedOptions.default,
+        answerValidationError: ''
       },
       {
         immutable: true,
         question: '',
         isQuestionValid: ValidatedOptions.default,
+        questionValidationError: '',
         answer: '',
-        isAnswerValid: ValidatedOptions.default
+        isAnswerValid: ValidatedOptions.default,
+        answerValidationError: ''
       }
     ]
-  };
+  });
 
+  // Initialize seedExamples with unique objects
   const [seedExamples, setSeedExamples] = useState<KnowledgeSeedExample[]>([
-    emptySeedExample,
-    emptySeedExample,
-    emptySeedExample,
-    emptySeedExample,
-    emptySeedExample
+    createEmptySeedExample(),
+    createEmptySeedExample(),
+    createEmptySeedExample(),
+    createEmptySeedExample(),
+    createEmptySeedExample()
   ]);
 
   useEffect(() => {
@@ -170,14 +198,32 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
       setRevision(knowledgeEditFormData.knowledgeFormData.revision);
       setLicenseWork(knowledgeEditFormData.knowledgeFormData.licenseWork);
       setCreators(knowledgeEditFormData.knowledgeFormData.creators);
-      setSeedExamples(knowledgeEditFormData.knowledgeFormData.seedExamples);
+
+      setSeedExamples(() =>
+        knowledgeEditFormData.knowledgeFormData.seedExamples.map((example) => ({
+          ...example,
+          immutable: example.immutable !== undefined ? example.immutable : true, // Ensure immutable is set
+          isContextValid: example.isContextValid || ValidatedOptions.default,
+          validationError: example.validationError || '',
+          questionAndAnswers: example.questionAndAnswers.map((qa) => ({
+            ...qa,
+            immutable: qa.immutable !== undefined ? qa.immutable : true, // Ensure immutable is set
+            isQuestionValid: qa.isQuestionValid || ValidatedOptions.default,
+            questionValidationError: qa.questionValidationError || '',
+            isAnswerValid: qa.isAnswerValid || ValidatedOptions.default,
+            answerValidationError: qa.answerValidationError || ''
+          }))
+        }))
+      );
+
+      console.log('Seed Examples Set from Edit Form Data:', knowledgeEditFormData.knowledgeFormData.seedExamples);
     }
   }, [knowledgeEditFormData]);
 
   const validateContext = (context: string) => {
     // Split the context into words based on spaces
     const contextStr = context.trim();
-    if (contextStr.length == 0) {
+    if (contextStr.length === 0) {
       setDisableAction(true);
       return { msg: 'Context is required', status: ValidatedOptions.error };
     }
@@ -193,7 +239,7 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
 
   const validateQuestion = (question: string) => {
     const questionStr = question.trim();
-    if (questionStr.length == 0) {
+    if (questionStr.length === 0) {
       setDisableAction(true);
       return { msg: 'Question is required', status: ValidatedOptions.error };
     }
@@ -208,7 +254,7 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
 
   const validateAnswer = (answer: string) => {
     const answerStr = answer.trim();
-    if (answerStr.length == 0) {
+    if (answerStr.length === 0) {
       setDisableAction(true);
       return { msg: 'Answer is required', status: ValidatedOptions.error };
     }
@@ -222,8 +268,8 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
   };
 
   const handleContextInputChange = (seedExampleIndex: number, contextValue: string): void => {
-    setSeedExamples(
-      seedExamples.map((seedExample: KnowledgeSeedExample, index: number) =>
+    setSeedExamples((prevSeedExamples) =>
+      prevSeedExamples.map((seedExample: KnowledgeSeedExample, index: number) =>
         index === seedExampleIndex
           ? {
               ...seedExample,
@@ -235,28 +281,30 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
   };
 
   const handleContextBlur = (seedExampleIndex: number): void => {
-    const updatedSeedExamples = seedExamples.map((seedExample: KnowledgeSeedExample, index: number): KnowledgeSeedExample => {
-      if (index === seedExampleIndex) {
-        const { msg, status } = validateContext(seedExample.context);
-        return {
-          ...seedExample,
-          isContextValid: status,
-          validationError: msg
-        };
-      }
-      return seedExample;
-    });
-    setSeedExamples(updatedSeedExamples);
+    setSeedExamples((prevSeedExamples) =>
+      prevSeedExamples.map((seedExample: KnowledgeSeedExample, index: number): KnowledgeSeedExample => {
+        if (index === seedExampleIndex) {
+          const { msg, status } = validateContext(seedExample.context);
+          console.log(`Context Validation for Seed Example ${seedExampleIndex + 1}: ${msg} (${status})`);
+          return {
+            ...seedExample,
+            isContextValid: status,
+            validationError: msg
+          };
+        }
+        return seedExample;
+      })
+    );
   };
 
   const handleQuestionInputChange = (seedExampleIndex: number, questionAndAnswerIndex: number, questionValue: string): void => {
-    setSeedExamples(
-      seedExamples.map((seedExample: KnowledgeSeedExample, index: number) =>
+    setSeedExamples((prevSeedExamples) =>
+      prevSeedExamples.map((seedExample: KnowledgeSeedExample, index: number) =>
         index === seedExampleIndex
           ? {
               ...seedExample,
-              questionAndAnswers: seedExample.questionAndAnswers.map((questionAndAnswerPair: QuestionAndAnswerPair, index: number) =>
-                index === questionAndAnswerIndex
+              questionAndAnswers: seedExample.questionAndAnswers.map((questionAndAnswerPair: QuestionAndAnswerPair, qaIndex: number) =>
+                qaIndex === questionAndAnswerIndex
                   ? {
                       ...questionAndAnswerPair,
                       question: questionValue
@@ -267,17 +315,21 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
           : seedExample
       )
     );
+    console.log(`Question Input Changed for Seed Example ${seedExampleIndex + 1}, Q&A Pair ${questionAndAnswerIndex + 1}: "${questionValue}"`);
   };
 
   const handleQuestionBlur = (seedExampleIndex: number, questionAndAnswerIndex: number): void => {
-    setSeedExamples(
-      seedExamples.map((seedExample: KnowledgeSeedExample, index: number) =>
+    setSeedExamples((prevSeedExamples) =>
+      prevSeedExamples.map((seedExample: KnowledgeSeedExample, index: number) =>
         index === seedExampleIndex
           ? {
               ...seedExample,
-              questionAndAnswers: seedExample.questionAndAnswers.map((questionAndAnswerPair: QuestionAndAnswerPair, index: number) => {
-                if (index === questionAndAnswerIndex) {
+              questionAndAnswers: seedExample.questionAndAnswers.map((questionAndAnswerPair: QuestionAndAnswerPair, qaIndex: number) => {
+                if (qaIndex === questionAndAnswerIndex) {
                   const { msg, status } = validateQuestion(questionAndAnswerPair.question);
+                  console.log(
+                    `Question Validation for Seed Example ${seedExampleIndex + 1}, Q&A Pair ${questionAndAnswerIndex + 1}: ${msg} (${status})`
+                  );
                   return {
                     ...questionAndAnswerPair,
                     isQuestionValid: status,
@@ -298,8 +350,8 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
         index === seedExampleIndex
           ? {
               ...seedExample,
-              questionAndAnswers: seedExample.questionAndAnswers.map((questionAndAnswerPair: QuestionAndAnswerPair, index: number) =>
-                index === questionAndAnswerIndex
+              questionAndAnswers: seedExample.questionAndAnswers.map((questionAndAnswerPair: QuestionAndAnswerPair, qaIndex: number) =>
+                qaIndex === questionAndAnswerIndex
                   ? {
                       ...questionAndAnswerPair,
                       answer: answerValue
@@ -313,13 +365,13 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
   };
 
   const handleAnswerBlur = (seedExampleIndex: number, questionAndAnswerIndex: number): void => {
-    setSeedExamples(
-      seedExamples.map((seedExample: KnowledgeSeedExample, index: number) =>
+    setSeedExamples((prevSeedExamples) =>
+      prevSeedExamples.map((seedExample: KnowledgeSeedExample, index: number) =>
         index === seedExampleIndex
           ? {
               ...seedExample,
-              questionAndAnswers: seedExample.questionAndAnswers.map((questionAndAnswerPair: QuestionAndAnswerPair, index: number) => {
-                if (index === questionAndAnswerIndex) {
+              questionAndAnswers: seedExample.questionAndAnswers.map((questionAndAnswerPair: QuestionAndAnswerPair, qaIndex: number) => {
+                if (qaIndex === questionAndAnswerIndex) {
                   const { msg, status } = validateAnswer(questionAndAnswerPair.answer);
                   return {
                     ...questionAndAnswerPair,
@@ -335,12 +387,56 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
     );
   };
 
-  // const toggleSeedExampleExpansion = (index: number): void => {
-  //   setSeedExamples(seedExamples.map((seedExample, idx) => (idx === index ? { ...seedExample, isExpanded: !seedExample.isExpanded } : seedExample)));
-  // };
-
   const toggleSeedExampleExpansion = (index: number): void => {
-    setSeedExamples(seedExamples.map((seedExample, idx) => (idx === index ? { ...seedExample, isExpanded: !seedExample.isExpanded } : seedExample)));
+    setSeedExamples((prevSeedExamples) =>
+      prevSeedExamples.map((seedExample, idx) => (idx === index ? { ...seedExample, isExpanded: !seedExample.isExpanded } : seedExample))
+    );
+    console.log(`toggleSeedExampleExpansion: Seed Example ${index + 1} expanded to ${!seedExamples[index].isExpanded}`);
+  };
+
+  // Function to append document information (Updated for single repositoryUrl and commitSha)
+  // Within src/components/Contribute/Native/index.tsx
+  const addDocumentInfoHandler = (repoUrl: string, commitShaValue: string, docName: string) => {
+    console.log(`addDocumentInfoHandler: repoUrl=${repoUrl}, commitSha=${commitShaValue}, docName=${docName}`);
+    if (knowledgeDocumentCommit && commitShaValue !== knowledgeDocumentCommit) {
+      console.error('Cannot add documents from different commit SHAs.');
+      setActionGroupAlertContent({
+        title: 'Invalid Selection',
+        message: 'All documents must be from the same commit SHA.',
+        success: false
+      });
+      return;
+    }
+
+    // Set commitSha if not already set
+    if (!knowledgeDocumentCommit) {
+      setKnowledgeDocumentCommit(commitShaValue);
+      console.log(`Set knowledgeDocumentCommit to: ${commitShaValue}`);
+
+      // Set repositoryUrl if not set
+      if (!knowledgeDocumentRepositoryUrl) {
+        const baseUrl = repoUrl.replace(/\/[^/]+$/, '');
+        setKnowledgeDocumentRepositoryUrl(baseUrl);
+        console.log(`Set knowledgeDocumentRepositoryUrl to: ${baseUrl}`);
+      }
+    }
+
+    // Add docName if not already present
+    // Split current documentName by comma and trim
+    setDocumentName((prevDocumentName) => {
+      const currentDocs = prevDocumentName
+        .split(',')
+        .map((d) => d.trim())
+        .filter((d) => d.length > 0);
+      if (!currentDocs.includes(docName)) {
+        const newList = currentDocs.length === 0 ? docName : currentDocs.join(', ') + ', ' + docName;
+        console.log(`Updated documentName: ${newList}`);
+        return newList;
+      } else {
+        console.log(`Document name "${docName}" is already added.`);
+        return prevDocumentName;
+      }
+    });
   };
 
   const onCloseActionGroupAlert = () => {
@@ -356,17 +452,19 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
     setKnowledgeDocumentRepositoryUrl('');
     setKnowledgeDocumentCommit('');
     setDocumentName('');
-    setTitleWork('');
-    setLinkWork('');
-    setLicenseWork('');
-    setCreators('');
-    setRevision('');
     setFilePath('');
-    setSeedExamples([emptySeedExample, emptySeedExample, emptySeedExample, emptySeedExample, emptySeedExample]);
+    setSeedExamples([
+      createEmptySeedExample(),
+      createEmptySeedExample(),
+      createEmptySeedExample(),
+      createEmptySeedExample(),
+      createEmptySeedExample()
+    ]);
     setDisableAction(true);
 
     // setReset is just reset button, value has no impact.
-    setReset(reset ? false : true);
+    setReset((prev) => !prev);
+    console.log('Knowledge Form Reset.');
   };
 
   const autoFillForm = (): void => {
@@ -375,9 +473,10 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
     setDocumentOutline(autoFillKnowledgeFields.documentOutline);
     setSubmissionSummary(autoFillKnowledgeFields.submissionSummary);
     setDomain(autoFillKnowledgeFields.domain);
-    setKnowledgeDocumentRepositoryUrl(autoFillKnowledgeFields.knowledgeDocumentRepositoryUrl);
+    setKnowledgeDocumentRepositoryUrl('~/.instructlab-ui/taxonomy-knowledge-docs');
     setKnowledgeDocumentCommit(autoFillKnowledgeFields.knowledgeDocumentCommit);
     setDocumentName(autoFillKnowledgeFields.documentName);
+    setFilePath(autoFillKnowledgeFields.filePath);
     setTitleWork(autoFillKnowledgeFields.titleWork);
     setLinkWork(autoFillKnowledgeFields.linkWork);
     setLicenseWork(autoFillKnowledgeFields.licenseWork);
@@ -387,17 +486,26 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
   };
   const yamlSeedExampleToFormSeedExample = (
     yamlSeedExamples: { context: string; questions_and_answers: { question: string; answer: string }[] }[]
-  ) => {
-    return yamlSeedExamples.map((yamlSeedExample) => ({
+  ): KnowledgeSeedExample[] => {
+    const mappedSeedExamples = yamlSeedExamples.map((yamlSeedExample) => ({
       immutable: true,
       isExpanded: false,
-      context: yamlSeedExample.context ?? '',
+      context: yamlSeedExample.context,
       isContextValid: ValidatedOptions.default,
-      questionAndAnswers: yamlSeedExample.questions_and_answers.map((questionAndAnswer) => ({
-        question: questionAndAnswer.question ?? '',
-        answer: questionAndAnswer.answer ?? ''
+      validationError: '',
+      questionAndAnswers: yamlSeedExample.questions_and_answers.map((qa) => ({
+        immutable: true,
+        question: qa.question,
+        answer: qa.answer,
+        isQuestionValid: ValidatedOptions.default,
+        questionValidationError: '',
+        isAnswerValid: ValidatedOptions.default,
+        answerValidationError: ''
       }))
-    })) as KnowledgeSeedExample[];
+    }));
+
+    console.log('Mapped Seed Examples from YAML:', mappedSeedExamples);
+    return mappedSeedExamples;
   };
 
   const onYamlUploadKnowledgeFillForm = (data: KnowledgeYamlData): void => {
@@ -409,32 +517,47 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
     setKnowledgeDocumentCommit(data.document.commit ?? '');
     setDocumentName(data.document.patterns.join(', ') ?? '');
     setSeedExamples(yamlSeedExampleToFormSeedExample(data.seed_examples));
+
+    // Optionally, set a success alert
+    setActionGroupAlertContent({
+      title: 'YAML Uploaded Successfully',
+      message: 'Your knowledge form has been populated based on the uploaded YAML file.',
+      success: true
+    });
   };
 
   const knowledgeFormData: KnowledgeFormData = {
-    email: email,
-    name: name,
-    submissionSummary: submissionSummary,
-    domain: domain,
-    documentOutline: documentOutline,
-    filePath: filePath,
-    seedExamples: seedExamples,
-    knowledgeDocumentRepositoryUrl: knowledgeDocumentRepositoryUrl,
-    knowledgeDocumentCommit: knowledgeDocumentCommit,
-    documentName: documentName,
-    titleWork: titleWork,
-    linkWork: linkWork,
-    revision: revision,
-    licenseWork: licenseWork,
-    creators: creators
+    email,
+    name,
+    submissionSummary,
+    domain,
+    documentOutline,
+    filePath,
+    seedExamples,
+    knowledgeDocumentRepositoryUrl,
+    knowledgeDocumentCommit,
+    documentName,
+    titleWork,
+    linkWork,
+    revision,
+    licenseWork,
+    creators
   };
+
+  console.log('Constructed knowledgeFormData:', knowledgeFormData); // Logging
+
+  useEffect(() => {
+    console.log('Seed Examples Updated:', seedExamples);
+  }, [seedExamples]);
 
   useEffect(() => {
     setDisableAction(!checkKnowledgeFormCompletion(knowledgeFormData));
+    console.log(`Action Disabled: ${!checkKnowledgeFormCompletion(knowledgeFormData)}`);
   }, [knowledgeFormData]);
 
   const handleCancel = () => {
     router.push('/dashboard');
+    console.log('Knowledge Form Cancelled. Redirecting to Dashboard.');
   };
 
   const steps = [
@@ -484,22 +607,6 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
       )
     },
     {
-      id: 'seed-examples',
-      name: 'Seed Examples',
-      component: (
-        <KnowledgeSeedExample
-          seedExamples={seedExamples}
-          handleContextInputChange={handleContextInputChange}
-          handleContextBlur={handleContextBlur}
-          handleQuestionInputChange={handleQuestionInputChange}
-          handleQuestionBlur={handleQuestionBlur}
-          handleAnswerInputChange={handleAnswerInputChange}
-          handleAnswerBlur={handleAnswerBlur}
-          toggleSeedExampleExpansion={toggleSeedExampleExpansion}
-        />
-      )
-    },
-    {
       id: 'document-info',
       name: 'Document Information',
       component: (
@@ -514,6 +621,39 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
           setKnowledgeDocumentCommit={setKnowledgeDocumentCommit}
           documentName={documentName}
           setDocumentName={setDocumentName}
+        />
+      )
+    },
+    {
+      id: 'seed-examples',
+      name: 'Seed Examples',
+      component: (
+        <KnowledgeSeedExampleNative
+          seedExamples={seedExamples}
+          handleContextInputChange={(idx, val) => {
+            handleContextInputChange(idx, val);
+          }}
+          handleContextBlur={(idx) => {
+            handleContextBlur(idx);
+          }}
+          handleQuestionInputChange={(sIdx, qaIdx, val) => {
+            handleQuestionInputChange(sIdx, qaIdx, val);
+          }}
+          handleQuestionBlur={(sIdx, qaIdx) => {
+            handleQuestionBlur(sIdx, qaIdx);
+          }}
+          handleAnswerInputChange={(sIdx, qaIdx, val) => {
+            handleAnswerInputChange(sIdx, qaIdx, val);
+          }}
+          handleAnswerBlur={(sIdx, qaIdx) => {
+            handleAnswerBlur(sIdx, qaIdx);
+          }}
+          toggleSeedExampleExpansion={(idx) => {
+            toggleSeedExampleExpansion(idx);
+          }}
+          addDocumentInfo={addDocumentInfoHandler}
+          repositoryUrl={knowledgeDocumentRepositoryUrl}
+          commitSha={knowledgeDocumentCommit}
         />
       )
     },
@@ -572,7 +712,7 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
               </Button>
             )}
             {'  '}
-            <Button variant="secondary" aria-label="User upload of pre-existing yaml file" onClick={() => setIsModalOpen(true)}>
+            <Button variant="secondary" aria-label="User upload of pre-existing yaml file" onClick={() => setIsYamlModalOpen(true)}>
               Upload a YAML file
             </Button>
           </FlexItem>
@@ -582,8 +722,8 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
           <KnowledgeDescriptionContent />
         </Content>
         <YamlFileUploadModal
-          isModalOpen={isModalOpen}
-          setIsModalOpen={setIsModalOpen}
+          isModalOpen={isYamlModalOpen}
+          setIsModalOpen={setIsYamlModalOpen}
           isKnowledgeForm={true}
           onYamlUploadKnowledgeFillForm={onYamlUploadKnowledgeFillForm}
         />
@@ -601,7 +741,7 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
             <Alert
               variant={actionGroupAlertContent.waitAlert ? 'info' : actionGroupAlertContent.success ? 'success' : 'danger'}
               title={actionGroupAlertContent.title}
-              timeout={actionGroupAlertContent.timeout == false ? false : actionGroupAlertContent.timeout}
+              timeout={actionGroupAlertContent.timeout === false ? false : actionGroupAlertContent.timeout}
               onTimeout={onCloseActionGroupAlert}
               actionClose={<AlertActionCloseButton onClose={onCloseActionGroupAlert} />}
             >

--- a/src/components/Contribute/Knowledge/Native/index.tsx
+++ b/src/components/Contribute/Knowledge/Native/index.tsx
@@ -42,6 +42,7 @@ import {
   Spinner,
   ActionGroup
 } from '@patternfly/react-core';
+import { devLog } from '@/utils/devlog';
 
 export interface ActionGroupAlertContent {
   title: string;
@@ -216,7 +217,7 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
         }))
       );
 
-      console.log('Seed Examples Set from Edit Form Data:', knowledgeEditFormData.knowledgeFormData.seedExamples);
+      devLog('Seed Examples Set from Edit Form Data:', knowledgeEditFormData.knowledgeFormData.seedExamples);
     }
   }, [knowledgeEditFormData]);
 
@@ -285,7 +286,7 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
       prevSeedExamples.map((seedExample: KnowledgeSeedExample, index: number): KnowledgeSeedExample => {
         if (index === seedExampleIndex) {
           const { msg, status } = validateContext(seedExample.context);
-          console.log(`Context Validation for Seed Example ${seedExampleIndex + 1}: ${msg} (${status})`);
+          devLog(`Context Validation for Seed Example ${seedExampleIndex + 1}: ${msg} (${status})`);
           return {
             ...seedExample,
             isContextValid: status,
@@ -315,7 +316,7 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
           : seedExample
       )
     );
-    console.log(`Question Input Changed for Seed Example ${seedExampleIndex + 1}, Q&A Pair ${questionAndAnswerIndex + 1}: "${questionValue}"`);
+    devLog(`Question Input Changed for Seed Example ${seedExampleIndex + 1}, Q&A Pair ${questionAndAnswerIndex + 1}: "${questionValue}"`);
   };
 
   const handleQuestionBlur = (seedExampleIndex: number, questionAndAnswerIndex: number): void => {
@@ -327,9 +328,7 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
               questionAndAnswers: seedExample.questionAndAnswers.map((questionAndAnswerPair: QuestionAndAnswerPair, qaIndex: number) => {
                 if (qaIndex === questionAndAnswerIndex) {
                   const { msg, status } = validateQuestion(questionAndAnswerPair.question);
-                  console.log(
-                    `Question Validation for Seed Example ${seedExampleIndex + 1}, Q&A Pair ${questionAndAnswerIndex + 1}: ${msg} (${status})`
-                  );
+                  devLog(`Question Validation for Seed Example ${seedExampleIndex + 1}, Q&A Pair ${questionAndAnswerIndex + 1}: ${msg} (${status})`);
                   return {
                     ...questionAndAnswerPair,
                     isQuestionValid: status,
@@ -391,13 +390,13 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
     setSeedExamples((prevSeedExamples) =>
       prevSeedExamples.map((seedExample, idx) => (idx === index ? { ...seedExample, isExpanded: !seedExample.isExpanded } : seedExample))
     );
-    console.log(`toggleSeedExampleExpansion: Seed Example ${index + 1} expanded to ${!seedExamples[index].isExpanded}`);
+    devLog(`toggleSeedExampleExpansion: Seed Example ${index + 1} expanded to ${!seedExamples[index].isExpanded}`);
   };
 
   // Function to append document information (Updated for single repositoryUrl and commitSha)
   // Within src/components/Contribute/Native/index.tsx
   const addDocumentInfoHandler = (repoUrl: string, commitShaValue: string, docName: string) => {
-    console.log(`addDocumentInfoHandler: repoUrl=${repoUrl}, commitSha=${commitShaValue}, docName=${docName}`);
+    devLog(`addDocumentInfoHandler: repoUrl=${repoUrl}, commitSha=${commitShaValue}, docName=${docName}`);
     if (knowledgeDocumentCommit && commitShaValue !== knowledgeDocumentCommit) {
       console.error('Cannot add documents from different commit SHAs.');
       setActionGroupAlertContent({
@@ -411,13 +410,13 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
     // Set commitSha if not already set
     if (!knowledgeDocumentCommit) {
       setKnowledgeDocumentCommit(commitShaValue);
-      console.log(`Set knowledgeDocumentCommit to: ${commitShaValue}`);
+      devLog(`Set knowledgeDocumentCommit to: ${commitShaValue}`);
 
       // Set repositoryUrl if not set
       if (!knowledgeDocumentRepositoryUrl) {
         const baseUrl = repoUrl.replace(/\/[^/]+$/, '');
         setKnowledgeDocumentRepositoryUrl(baseUrl);
-        console.log(`Set knowledgeDocumentRepositoryUrl to: ${baseUrl}`);
+        devLog(`Set knowledgeDocumentRepositoryUrl to: ${baseUrl}`);
       }
     }
 
@@ -430,10 +429,10 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
         .filter((d) => d.length > 0);
       if (!currentDocs.includes(docName)) {
         const newList = currentDocs.length === 0 ? docName : currentDocs.join(', ') + ', ' + docName;
-        console.log(`Updated documentName: ${newList}`);
+        devLog(`Updated documentName: ${newList}`);
         return newList;
       } else {
-        console.log(`Document name "${docName}" is already added.`);
+        devLog(`Document name "${docName}" is already added.`);
         return prevDocumentName;
       }
     });
@@ -464,7 +463,7 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
 
     // setReset is just reset button, value has no impact.
     setReset((prev) => !prev);
-    console.log('Knowledge Form Reset.');
+    devLog('Knowledge Form Reset.');
   };
 
   const autoFillForm = (): void => {
@@ -504,7 +503,7 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
       }))
     }));
 
-    console.log('Mapped Seed Examples from YAML:', mappedSeedExamples);
+    devLog('Mapped Seed Examples from YAML:', mappedSeedExamples);
     return mappedSeedExamples;
   };
 
@@ -544,20 +543,18 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
     creators
   };
 
-  console.log('Constructed knowledgeFormData:', knowledgeFormData); // Logging
+  devLog('Constructed knowledgeFormData:', knowledgeFormData);
 
   useEffect(() => {
-    console.log('Seed Examples Updated:', seedExamples);
+    devLog('Seed Examples Updated:', seedExamples);
   }, [seedExamples]);
 
   useEffect(() => {
     setDisableAction(!checkKnowledgeFormCompletion(knowledgeFormData));
-    console.log(`Action Disabled: ${!checkKnowledgeFormCompletion(knowledgeFormData)}`);
   }, [knowledgeFormData]);
 
   const handleCancel = () => {
     router.push('/dashboard');
-    console.log('Knowledge Form Cancelled. Redirecting to Dashboard.');
   };
 
   const steps = [

--- a/src/components/Contribute/Knowledge/ReviewSubmission/index.tsx
+++ b/src/components/Contribute/Knowledge/ReviewSubmission/index.tsx
@@ -23,19 +23,19 @@ export const ReviewSubmission: React.FC<ReviewSubmissionProps> = ({ knowledgeFor
       {/* Knowledge Information */}
       <h3>Knowledge Information</h3>
       <p>
-        <strong>Submission Summary:</strong> {knowledgeFormData.submissionSummary || 'N/A'}
+        <strong>Submission Summary:</strong> {knowledgeFormData.submissionSummary}
       </p>
       <p>
-        <strong>Domain:</strong> {knowledgeFormData.domain || 'N/A'}
+        <strong>Domain:</strong> {knowledgeFormData.domain}
       </p>
       <p>
-        <strong>Document Outline:</strong> {knowledgeFormData.documentOutline || 'N/A'}
+        <strong>Document Outline:</strong> {knowledgeFormData.documentOutline}
       </p>
 
       {/* File Path Information */}
       <h3>File Path Information</h3>
       <p>
-        <strong>File Path:</strong> {knowledgeFormData.filePath || 'N/A'}
+        <strong>File Path:</strong> {knowledgeFormData.filePath}
       </p>
 
       {/* Seed Examples */}
@@ -44,15 +44,15 @@ export const ReviewSubmission: React.FC<ReviewSubmissionProps> = ({ knowledgeFor
         <div key={index}>
           <h4>Seed Example {index + 1}</h4>
           <p>
-            <strong>Context:</strong> {seedExample.context || 'N/A'}
+            <strong>Context:</strong> {seedExample.context}
           </p>
           {seedExample.questionAndAnswers.map((qa, qaIndex) => (
             <div key={qaIndex}>
               <p>
-                <strong>Question {qaIndex + 1}:</strong> {qa.question || 'N/A'}
+                <strong>Question {qaIndex + 1}:</strong> {qa.question}
               </p>
               <p>
-                <strong>Answer {qaIndex + 1}:</strong> {qa.answer || 'N/A'}
+                <strong>Answer {qaIndex + 1}:</strong> {qa.answer}
               </p>
             </div>
           ))}
@@ -61,38 +61,32 @@ export const ReviewSubmission: React.FC<ReviewSubmissionProps> = ({ knowledgeFor
 
       {/* Document Information */}
       <h3>Document Information</h3>
-      {knowledgeFormData.knowledgeDocumentRepositoryUrl && knowledgeFormData.knowledgeDocumentCommit ? (
-        <div>
-          <p>
-            <strong>Repository URL:</strong> {knowledgeFormData.knowledgeDocumentRepositoryUrl}
-          </p>
-          <p>
-            <strong>Commit SHA:</strong> {knowledgeFormData.knowledgeDocumentCommit}
-          </p>
-          <p>
-            <strong>Document Names:</strong> {knowledgeFormData.documentName || 'N/A'}
-          </p>
-        </div>
-      ) : (
-        <p>No Document Information Provided.</p>
-      )}
+      <p>
+        <strong>Repository URL:</strong> {knowledgeFormData.knowledgeDocumentRepositoryUrl}
+      </p>
+      <p>
+        <strong>Commit:</strong> {knowledgeFormData.knowledgeDocumentCommit}
+      </p>
+      <p>
+        <strong>Document Name:</strong> {knowledgeFormData.documentName}
+      </p>
 
       {/* Attribution Information */}
       <h3>Attribution Information</h3>
       <p>
-        <strong>Title of Work:</strong> {knowledgeFormData.titleWork || 'N/A'}
+        <strong>Title of Work:</strong> {knowledgeFormData.titleWork}
       </p>
       <p>
-        <strong>Link to Work:</strong> {knowledgeFormData.linkWork || 'N/A'}
+        <strong>Link to Work:</strong> {knowledgeFormData.linkWork}
       </p>
       <p>
-        <strong>Revision:</strong> {knowledgeFormData.revision || 'N/A'}
+        <strong>Revision:</strong> {knowledgeFormData.revision}
       </p>
       <p>
-        <strong>License of Work:</strong> {knowledgeFormData.licenseWork || 'N/A'}
+        <strong>License of Work:</strong> {knowledgeFormData.licenseWork}
       </p>
       <p>
-        <strong>Creators:</strong> {knowledgeFormData.creators || 'N/A'}
+        <strong>Creators:</strong> {knowledgeFormData.creators}
       </p>
     </div>
   );

--- a/src/components/Contribute/Knowledge/ReviewSubmission/index.tsx
+++ b/src/components/Contribute/Knowledge/ReviewSubmission/index.tsx
@@ -23,19 +23,19 @@ export const ReviewSubmission: React.FC<ReviewSubmissionProps> = ({ knowledgeFor
       {/* Knowledge Information */}
       <h3>Knowledge Information</h3>
       <p>
-        <strong>Submission Summary:</strong> {knowledgeFormData.submissionSummary}
+        <strong>Submission Summary:</strong> {knowledgeFormData.submissionSummary || 'N/A'}
       </p>
       <p>
-        <strong>Domain:</strong> {knowledgeFormData.domain}
+        <strong>Domain:</strong> {knowledgeFormData.domain || 'N/A'}
       </p>
       <p>
-        <strong>Document Outline:</strong> {knowledgeFormData.documentOutline}
+        <strong>Document Outline:</strong> {knowledgeFormData.documentOutline || 'N/A'}
       </p>
 
       {/* File Path Information */}
       <h3>File Path Information</h3>
       <p>
-        <strong>File Path:</strong> {knowledgeFormData.filePath}
+        <strong>File Path:</strong> {knowledgeFormData.filePath || 'N/A'}
       </p>
 
       {/* Seed Examples */}
@@ -44,15 +44,15 @@ export const ReviewSubmission: React.FC<ReviewSubmissionProps> = ({ knowledgeFor
         <div key={index}>
           <h4>Seed Example {index + 1}</h4>
           <p>
-            <strong>Context:</strong> {seedExample.context}
+            <strong>Context:</strong> {seedExample.context || 'N/A'}
           </p>
           {seedExample.questionAndAnswers.map((qa, qaIndex) => (
             <div key={qaIndex}>
               <p>
-                <strong>Question {qaIndex + 1}:</strong> {qa.question}
+                <strong>Question {qaIndex + 1}:</strong> {qa.question || 'N/A'}
               </p>
               <p>
-                <strong>Answer {qaIndex + 1}:</strong> {qa.answer}
+                <strong>Answer {qaIndex + 1}:</strong> {qa.answer || 'N/A'}
               </p>
             </div>
           ))}
@@ -61,32 +61,38 @@ export const ReviewSubmission: React.FC<ReviewSubmissionProps> = ({ knowledgeFor
 
       {/* Document Information */}
       <h3>Document Information</h3>
-      <p>
-        <strong>Repository URL:</strong> {knowledgeFormData.knowledgeDocumentRepositoryUrl}
-      </p>
-      <p>
-        <strong>Commit:</strong> {knowledgeFormData.knowledgeDocumentCommit}
-      </p>
-      <p>
-        <strong>Document Name:</strong> {knowledgeFormData.documentName}
-      </p>
+      {knowledgeFormData.knowledgeDocumentRepositoryUrl && knowledgeFormData.knowledgeDocumentCommit ? (
+        <div>
+          <p>
+            <strong>Repository URL:</strong> {knowledgeFormData.knowledgeDocumentRepositoryUrl}
+          </p>
+          <p>
+            <strong>Commit SHA:</strong> {knowledgeFormData.knowledgeDocumentCommit}
+          </p>
+          <p>
+            <strong>Document Names:</strong> {knowledgeFormData.documentName || 'N/A'}
+          </p>
+        </div>
+      ) : (
+        <p>No Document Information Provided.</p>
+      )}
 
       {/* Attribution Information */}
       <h3>Attribution Information</h3>
       <p>
-        <strong>Title of Work:</strong> {knowledgeFormData.titleWork}
+        <strong>Title of Work:</strong> {knowledgeFormData.titleWork || 'N/A'}
       </p>
       <p>
-        <strong>Link to Work:</strong> {knowledgeFormData.linkWork}
+        <strong>Link to Work:</strong> {knowledgeFormData.linkWork || 'N/A'}
       </p>
       <p>
-        <strong>Revision:</strong> {knowledgeFormData.revision}
+        <strong>Revision:</strong> {knowledgeFormData.revision || 'N/A'}
       </p>
       <p>
-        <strong>License of Work:</strong> {knowledgeFormData.licenseWork}
+        <strong>License of Work:</strong> {knowledgeFormData.licenseWork || 'N/A'}
       </p>
       <p>
-        <strong>Creators:</strong> {knowledgeFormData.creators}
+        <strong>Creators:</strong> {knowledgeFormData.creators || 'N/A'}
       </p>
     </div>
   );

--- a/src/components/Contribute/Knowledge/UploadFile.tsx
+++ b/src/components/Contribute/Knowledge/UploadFile.tsx
@@ -1,6 +1,20 @@
 // src/components/Contribute/Knowledge/UploadFile.tsx
 'use client';
-import { HelperText, HelperTextItem, MultipleFileUpload, MultipleFileUploadMain, Spinner, MultipleFileUploadStatus, MultipleFileUploadStatusItem, Modal, Button, ModalBody, ModalFooter, ModalHeader, ModalVariant } from '@patternfly/react-core';
+import {
+  HelperText,
+  HelperTextItem,
+  MultipleFileUpload,
+  MultipleFileUploadMain,
+  Spinner,
+  MultipleFileUploadStatus,
+  MultipleFileUploadStatusItem,
+  Modal,
+  Button,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant
+} from '@patternfly/react-core';
 import { UploadIcon } from '@patternfly/react-icons';
 import React, { useState, useEffect } from 'react';
 import { FileRejection, DropEvent } from 'react-dropzone';
@@ -163,15 +177,13 @@ export const UploadFile: React.FunctionComponent<{ onFilesChange: (files: File[]
               {modalText}
               <br />
             </p>
-
           </ModalBody>
-          <ModalFooter >
+          <ModalFooter>
             <Button key="close" variant="secondary" onClick={() => setModalText('')}>
               Close
             </Button>
           </ModalFooter>
         </Modal>
-
       </MultipleFileUpload>
     </div>
   );

--- a/src/components/Contribute/Skill/AttributionInformation/AttributionInformation.tsx
+++ b/src/components/Contribute/Skill/AttributionInformation/AttributionInformation.tsx
@@ -1,7 +1,16 @@
 import React, { useEffect } from 'react';
 import { checkSkillFormCompletion } from '../validation';
 import { SkillFormData } from '@/types';
-import { ValidatedOptions, FormFieldGroupExpandable, FormFieldGroupHeader, FormGroup, TextInput, FormHelperText, HelperText, HelperTextItem } from '@patternfly/react-core';
+import {
+  ValidatedOptions,
+  FormFieldGroupExpandable,
+  FormFieldGroupHeader,
+  FormGroup,
+  TextInput,
+  FormHelperText,
+  HelperText,
+  HelperTextItem
+} from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 interface Props {

--- a/src/components/Contribute/Skill/Github/index.tsx
+++ b/src/components/Contribute/Skill/Github/index.tsx
@@ -18,7 +18,25 @@ import SkillsInformation from '../SkillsInformation/SkillsInformation';
 import SkillsDescriptionContent from '../SkillsDescription/SkillsDescriptionContent';
 import { autoFillSkillsFields } from '../AutoFill';
 import { YamlFileUploadModal } from '../../YamlFileUploadModal';
-import { ValidatedOptions, PageGroup, PageBreadcrumb, Breadcrumb, BreadcrumbItem, PageSection, Flex, FlexItem, Title, Button, Content, Form, AlertGroup, Alert, AlertActionCloseButton, Spinner, ActionGroup } from '@patternfly/react-core';
+import {
+  ValidatedOptions,
+  PageGroup,
+  PageBreadcrumb,
+  Breadcrumb,
+  BreadcrumbItem,
+  PageSection,
+  Flex,
+  FlexItem,
+  Title,
+  Button,
+  Content,
+  Form,
+  AlertGroup,
+  Alert,
+  AlertActionCloseButton,
+  Spinner,
+  ActionGroup
+} from '@patternfly/react-core';
 import AuthorInformation, { FormType } from '../../AuthorInformation';
 
 export interface SkillEditFormData {

--- a/src/components/Contribute/Skill/Native/index.tsx
+++ b/src/components/Contribute/Skill/Native/index.tsx
@@ -19,7 +19,25 @@ import SkillsInformation from '@/components/Contribute/Skill/SkillsInformation/S
 import SkillsDescriptionContent from '@/components/Contribute/Skill/SkillsDescription/SkillsDescriptionContent';
 import { autoFillSkillsFields } from '@/components/Contribute/Skill/AutoFill';
 import { YamlFileUploadModal } from '../../YamlFileUploadModal';
-import { ValidatedOptions, PageGroup, PageBreadcrumb, Breadcrumb, BreadcrumbItem, PageSection, Flex, FlexItem, Title, Button, Content, Form, AlertGroup, Alert, AlertActionCloseButton, Spinner, ActionGroup } from '@patternfly/react-core';
+import {
+  ValidatedOptions,
+  PageGroup,
+  PageBreadcrumb,
+  Breadcrumb,
+  BreadcrumbItem,
+  PageSection,
+  Flex,
+  FlexItem,
+  Title,
+  Button,
+  Content,
+  Form,
+  AlertGroup,
+  Alert,
+  AlertActionCloseButton,
+  Spinner,
+  ActionGroup
+} from '@patternfly/react-core';
 
 export interface SkillEditFormData {
   isEditForm: boolean;

--- a/src/components/Contribute/Skill/SkillsInformation/SkillsInformation.tsx
+++ b/src/components/Contribute/Skill/SkillsInformation/SkillsInformation.tsx
@@ -1,7 +1,16 @@
 import React, { useEffect } from 'react';
 import { checkSkillFormCompletion } from '../validation';
 import { SkillFormData } from '@/types';
-import { ValidatedOptions, FormFieldGroupExpandable, FormFieldGroupHeader, FormGroup, TextInput, HelperText, HelperTextItem, TextArea } from '@patternfly/react-core';
+import {
+  ValidatedOptions,
+  FormFieldGroupExpandable,
+  FormFieldGroupHeader,
+  FormGroup,
+  TextInput,
+  HelperText,
+  HelperTextItem,
+  TextArea
+} from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 interface Props {

--- a/src/components/Contribute/Skill/SkillsSeedExample/SkillsSeedExample.tsx
+++ b/src/components/Contribute/Skill/SkillsSeedExample/SkillsSeedExample.tsx
@@ -1,6 +1,16 @@
 import React from 'react';
 import { SkillSeedExample } from '@/types';
-import { FormFieldGroupExpandable, FormFieldGroupHeader, Button, FormGroup, TextArea, ValidatedOptions, FormHelperText, HelperText, HelperTextItem } from '@patternfly/react-core';
+import {
+  FormFieldGroupExpandable,
+  FormFieldGroupHeader,
+  Button,
+  FormGroup,
+  TextArea,
+  ValidatedOptions,
+  FormHelperText,
+  HelperText,
+  HelperTextItem
+} from '@patternfly/react-core';
 import { ExternalLinkAltIcon, TrashIcon, ExclamationCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 interface Props {

--- a/src/components/Dashboard/Github/dashboard.tsx
+++ b/src/components/Dashboard/Github/dashboard.tsx
@@ -6,7 +6,31 @@ import { useRouter } from 'next/navigation';
 import { fetchPullRequests, getGitHubUsername } from '../../../utils/github';
 import { PullRequest } from '../../../types';
 import { useState } from 'react';
-import { PageBreadcrumb, Breadcrumb, BreadcrumbItem, PageSection, Title, Content, Popover, Button, Modal, ModalVariant, Spinner, EmptyState, EmptyStateBody, EmptyStateFooter, EmptyStateActions, Stack, StackItem, Card, CardTitle, CardBody, Flex, FlexItem, Label } from '@patternfly/react-core';
+import {
+  PageBreadcrumb,
+  Breadcrumb,
+  BreadcrumbItem,
+  PageSection,
+  Title,
+  Content,
+  Popover,
+  Button,
+  Modal,
+  ModalVariant,
+  Spinner,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateActions,
+  Stack,
+  StackItem,
+  Card,
+  CardTitle,
+  CardBody,
+  Flex,
+  FlexItem,
+  Label
+} from '@patternfly/react-core';
 import { ExternalLinkAltIcon, OutlinedQuestionCircleIcon, GithubIcon } from '@patternfly/react-icons';
 
 const InstructLabLogo: React.FC = () => <Image src="/InstructLab-LogoFile-RGB-FullColor.svg" alt="InstructLab Logo" width={256} height={256} />;

--- a/src/components/GithubAccessPopup/index.tsx
+++ b/src/components/GithubAccessPopup/index.tsx
@@ -31,7 +31,6 @@ const GithubAccessPopup: React.FunctionComponent<Props> = ({ onAccept }) => {
   };
 
   return (
-
     <Modal
       variant={ModalVariant.medium}
       title="GitHub Access Permissions"
@@ -43,8 +42,8 @@ const GithubAccessPopup: React.FunctionComponent<Props> = ({ onAccept }) => {
       <ModalHeader title="GitHub Access Permissions" labelId="github-access-warn-modal-title" titleIconVariant="warning" />
       <ModalBody id="github-access-warn-body-variant">
         <p>
-          To allow InstructLab UI to manage your taxonomy submissions, you must grant read and write permissions to your GitHub account. InstructLab UI
-          will use your account to:
+          To allow InstructLab UI to manage your taxonomy submissions, you must grant read and write permissions to your GitHub account. InstructLab
+          UI will use your account to:
           <br />
           <br />
           <li>
@@ -76,18 +75,17 @@ const GithubAccessPopup: React.FunctionComponent<Props> = ({ onAccept }) => {
           grant these permissions, select <b>deny</b> to sign out of InstructLab UI.
           <br />
         </p>
-
       </ModalBody>
-      <ModalFooter >
+      <ModalFooter>
         <Button key="confirm" variant="primary" onClick={() => setDecisionAndClose()}>
           Accept
-        </Button>,
+        </Button>
+        ,
         <Button key="cancel" variant="secondary" onClick={() => signOut()}>
           Deny
         </Button>
       </ModalFooter>
     </Modal>
-
   );
 };
 

--- a/src/components/PathService/PathService.tsx
+++ b/src/components/PathService/PathService.tsx
@@ -1,5 +1,15 @@
 // /src/components/PathService.tsx
-import { ValidatedOptions, PopperProps, List, ListItem, SearchInput, FormHelperText, HelperText, HelperTextItem, Popper } from '@patternfly/react-core';
+import {
+  ValidatedOptions,
+  PopperProps,
+  List,
+  ListItem,
+  SearchInput,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Popper
+} from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import React, { useState, useEffect, useRef } from 'react';
 

--- a/src/components/YamlCodeModal/index.tsx
+++ b/src/components/YamlCodeModal/index.tsx
@@ -12,7 +12,6 @@ interface YamlCodeModalProps {
 
 export const YamlCodeModal: React.FC<YamlCodeModalProps> = ({ isModalOpen, handleModalToggle, yamlContent }) => {
   return (
-
     <Modal
       variant={ModalVariant.medium}
       title="Current YAML"
@@ -27,14 +26,14 @@ export const YamlCodeModal: React.FC<YamlCodeModalProps> = ({ isModalOpen, handl
           <CodeBlockCode>{yamlContent}</CodeBlockCode>
         </CodeBlock>
       </ModalBody>
-      <ModalFooter >
+      <ModalFooter>
         <Button key="close" variant="primary" onClick={handleModalToggle}>
           Close
-        </Button>,
+        </Button>
+        ,
         <CopyToClipboardButton key="copy" text={yamlContent} />
       </ModalFooter>
     </Modal>
-
   );
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import { ValidatedOptions } from "@patternfly/react-core";
+import { ValidatedOptions } from '@patternfly/react-core';
 
 export interface Endpoint {
   id: string;

--- a/src/utils/devlog.ts
+++ b/src/utils/devlog.ts
@@ -1,0 +1,7 @@
+// src/utils/devlog.ts
+
+export function devLog(...messages: unknown[]) {
+  if (process.env.NODE_ENV === 'development') {
+    console.log(...messages);
+  }
+}


### PR DESCRIPTION
- Adds routes for retrieving files from the local knowledge git
- Adds the ability to view the file changes/additions in the native dashboard.
- Enables the user to view the knowledge document, highlight the text they want to add to the context field and submit it. The highlighted text will get populated to the context field.
- Allows the user to still manually enter context or knowledge file details and handles the state switching when they choose to do so.
- Prevents the user from selecting context from a different commit SHA if they have already selected context from another SHA.
- Lets the user toggle all files in the knowledge files repo if they wanted to use a different file/SHA for context if they want to. Otherwise, the default is the latest commit. Probably the ideal scenario would be to return the SHA from the /api/native/git/upload or whatever the route is to return the SHA that could then be referenced and present the user with an empty state if it isn't defined but that would be a lot more code to an already too busy PR.

Note: this probably breaks the container deploy for native with the changes in `src/app/api/native/upload/route.ts`. It's not clear to me how to rebase into that if someone could take a look. I think @vishnoianil  did that if you don't mind good sir.

Not an easy review, there are a ton of different states getting munged together here UploadYaml/AutoFillYaml/DownloadYaml/ViewYaml/ManualKnowledgeFile to name a few. Did my best to juggle all of them but will def have some bugs to fix.
 
Demo vid:

https://github.com/user-attachments/assets/02768290-65c9-453f-88f5-756254db546c

