### PR TITLE
Add a docling service file conversion feature

### DIFF
--- a/.env.native.example
+++ b/.env.native.example
@@ -10,3 +10,5 @@ IL_ENABLE_DEV_MODE=true #Enable this option if you want to enable UI features th
 NEXT_PUBLIC_TAXONOMY_ROOT_DIR=
 
 NEXT_PUBLIC_EXPERIMENTAL_FEATURES=false
+
+# IL_FILE_CONVERSION_SERVICE=http://localhost:8000 # Uncomment and fill in the http://host:port if the docling conversion service is running.

--- a/src/app/api/native/convert/route.ts
+++ b/src/app/api/native/convert/route.ts
@@ -1,0 +1,68 @@
+// src/app/api/native/convert/route.ts
+import { NextResponse } from 'next/server';
+
+`use server`;
+
+interface ConvertRequestBody {
+  options?: {
+    output_markdown?: boolean;
+    include_images?: boolean;
+  };
+  file_source: {
+    base64_string: string;
+    filename: string;
+  };
+}
+
+// This route calls the external REST service to convert any doc => markdown
+export async function POST(request: Request) {
+  try {
+    // 1. Parse JSON body from client
+    const body: ConvertRequestBody = await request.json();
+
+    // 2. Read the IL_FILE_CONVERSION_SERVICE from .env (fallback to localhost if not set)
+    const baseUrl = process.env.IL_FILE_CONVERSION_SERVICE || 'http://localhost:8000';
+
+    // 3. Check the health of the conversion service before proceeding
+    const healthRes = await fetch(`${baseUrl}/health`);
+    if (!healthRes.ok) {
+      console.error('The file conversion service is offline or returned non-OK status:', healthRes.status, healthRes.statusText);
+      return NextResponse.json({ error: 'Conversion service is offline, only markdown files accepted.' }, { status: 503 });
+    }
+
+    // Parse the health response body in case we need to verify its "status":"ok"
+    const healthData = await healthRes.json();
+    if (!healthData.status || healthData.status !== 'ok') {
+      console.error('Doc->md conversion service health check response not "ok":', healthData);
+      return NextResponse.json({ error: 'Conversion service is offline, only markdown files accepted.' }, { status: 503 });
+    }
+
+    // 4. Service is healthy, proceed with md conversion
+    const res = await fetch(`${baseUrl}/convert/markdown`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(body)
+    });
+
+    if (!res.ok) {
+      console.error('Conversion service responded with error', res.status, res.statusText);
+      return NextResponse.json({ error: `Conversion service call failed. ${res.statusText}` }, { status: 500 });
+    }
+
+    // 5. Wait for the docling service to return the user submitted file converted to markdown
+    const data = await res.text();
+
+    // Return the markdown wrapped in JSON so the client side can parse it
+    return NextResponse.json({ content: data }, { status: 200 });
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error('Error during doc->md conversion route call:', error);
+      return NextResponse.json({ error: 'md conversion failed.', message: error.message }, { status: 500 });
+    } else {
+      console.error('Unknown error during conversion route call:', error);
+      return NextResponse.json({ error: 'conversion failed due to an unknown error.' }, { status: 500 });
+    }
+  }
+}

--- a/src/components/Contribute/Knowledge/Native/DocumentInformation/DocumentInformation.tsx
+++ b/src/components/Contribute/Knowledge/Native/DocumentInformation/DocumentInformation.tsx
@@ -1,24 +1,17 @@
 // src/components/Contribute/Knowledge/Native/DocumentInformation/DocumentInformation.tsx
 import React, { useEffect, useState } from 'react';
+import { FormFieldGroupHeader, FormGroup, FormHelperText } from '@patternfly/react-core/dist/dynamic/components/Form';
+import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
+import { TextInput } from '@patternfly/react-core/dist/dynamic/components/TextInput';
+import { Alert, AlertActionLink, AlertActionCloseButton } from '@patternfly/react-core/dist/dynamic/components/Alert';
+import { HelperText } from '@patternfly/react-core/dist/dynamic/components/HelperText';
+import { HelperTextItem } from '@patternfly/react-core/dist/dynamic/components/HelperText';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/dynamic/icons/exclamation-circle-icon';
+import { ValidatedOptions } from '@patternfly/react-core/dist/esm/helpers/constants';
+import { Modal, ModalVariant } from '@patternfly/react-core/dist/esm/deprecated/components/Modal/Modal';
 import { UploadFile } from '@/components/Contribute/Knowledge/UploadFile';
 import { checkKnowledgeFormCompletion } from '@/components/Contribute/Knowledge/validation';
 import { KnowledgeFormData } from '@/types';
-import {
-  ValidatedOptions,
-  FormFieldGroupHeader,
-  FormGroup,
-  Button,
-  Modal,
-  ModalVariant,
-  TextInput,
-  FormHelperText,
-  HelperText,
-  HelperTextItem,
-  Alert,
-  AlertActionCloseButton,
-  AlertActionLink
-} from '@patternfly/react-core';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 interface Props {
   reset: boolean;
@@ -252,24 +245,29 @@ const DocumentInformation: React.FC<Props> = ({
           </Button>
         </div>
       </FormGroup>
-      <Modal variant={ModalVariant.medium} title="Data Loss Warning" isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
-        <p>{modalText}</p>
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px', marginTop: '20px' }}>
-          <Button variant="secondary" onClick={handleModalContinue}>
+      <Modal
+        variant={ModalVariant.medium}
+        title="Data Loss Warning"
+        titleIconVariant="warning"
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        actions={[
+          <Button key="Continue" variant="secondary" onClick={handleModalContinue}>
             Continue
-          </Button>
-          <Button variant="secondary" onClick={() => setIsModalOpen(false)}>
+          </Button>,
+          <Button key="cancel" variant="secondary" onClick={() => setIsModalOpen(false)}>
             Cancel
           </Button>
-        </div>
+        ]}
+      >
+        <p>{modalText}</p>
       </Modal>
       {!useFileUpload ? (
         <>
           <FormGroup isRequired key={'doc-info-details-id'} label="Repo URL or Server Side File Path">
             <TextInput
               isRequired
-              // TODO: once all of the different potential filepaths/url/types are determined, add back stricter validation
-              type="text"
+              type="url"
               aria-label="repo"
               validated={validRepo}
               placeholder="Enter repo URL where document exists"
@@ -328,8 +326,6 @@ const DocumentInformation: React.FC<Props> = ({
           </Button>
         </>
       )}
-
-      {/* Informational Alert */}
       {alertInfo && (
         <Alert variant={alertInfo.type} title={alertInfo.title} actionClose={<AlertActionCloseButton onClose={() => setAlertInfo(undefined)} />}>
           {alertInfo.message}
@@ -340,8 +336,6 @@ const DocumentInformation: React.FC<Props> = ({
           )}
         </Alert>
       )}
-
-      {/* Success Alert */}
       {successAlertTitle && successAlertMessage && (
         <Alert
           variant="success"
@@ -358,8 +352,6 @@ const DocumentInformation: React.FC<Props> = ({
           {successAlertMessage}
         </Alert>
       )}
-
-      {/* Failure Alert */}
       {failureAlertTitle && failureAlertMessage && (
         <Alert variant="danger" title={failureAlertTitle} actionClose={<AlertActionCloseButton onClose={onCloseFailureAlert} />}>
           {failureAlertMessage}

--- a/src/components/Contribute/Knowledge/Native/KnowledgeQuestionAnswerPairsNative/KnowledgeQuestionAnswerPairs.tsx
+++ b/src/components/Contribute/Knowledge/Native/KnowledgeQuestionAnswerPairsNative/KnowledgeQuestionAnswerPairs.tsx
@@ -60,6 +60,8 @@ const KnowledgeQuestionAnswerPairsNative: React.FC<Props> = ({
   const [expandedFiles, setExpandedFiles] = useState<Record<string, boolean>>({});
   const [selectedWordCount, setSelectedWordCount] = useState<number>(0);
   const [showAllCommits, setShowAllCommits] = useState<boolean>(false);
+  const [contextWordCount, setContextWordCount] = useState(0);
+  const MAX_WORDS = 500;
 
   // Ref for the <pre> elements to track selections TODO: figure out how to make text expansions taller in PF without a custom-pre
   const preRefs = useRef<Record<string, HTMLPreElement | null>>({});
@@ -217,6 +219,27 @@ const KnowledgeQuestionAnswerPairsNative: React.FC<Props> = ({
     []
   );
 
+  // TODO: replace with a tokenizer library
+  const countWords = (text: string) => {
+    return text.trim().split(/\s+/).filter(Boolean).length;
+  };
+
+  // Update word count whenever context changes
+  useEffect(() => {
+    setContextWordCount(countWords(seedExample.context));
+  }, [seedExample.context]);
+
+  // Handle context input change with word count validation
+  const onContextChange = (_event: React.FormEvent<HTMLTextAreaElement>, contextValue: string) => {
+    const wordCount = countWords(contextValue);
+    if (wordCount <= MAX_WORDS) {
+      handleContextInputChange(seedExampleIndex, contextValue);
+    } else {
+      // allow the overage and show validation error
+      handleContextInputChange(seedExampleIndex, contextValue);
+    }
+  };
+
   return (
     <FormGroup style={{ padding: '20px' }}>
       <Tooltip content={<div>Select context from your knowledge files</div>} position="top">
@@ -232,11 +255,18 @@ const KnowledgeQuestionAnswerPairsNative: React.FC<Props> = ({
         placeholder="Enter the context from which the Q&A pairs are derived. (500 words max)"
         value={seedExample.context}
         validated={seedExample.isContextValid}
-        maxLength={500}
+        onChange={onContextChange}
         style={{ marginBottom: '20px' }}
-        onChange={(_event, contextValue: string) => handleContextInputChange(seedExampleIndex, contextValue)}
         onBlur={() => handleContextBlur(seedExampleIndex)}
       />
+      {/* Display word count */}
+      <FormHelperText>
+        <HelperText>
+          <HelperTextItem>
+            {contextWordCount} / {MAX_WORDS} words
+          </HelperTextItem>
+        </HelperText>
+      </FormHelperText>
       {seedExample.isContextValid === ValidatedOptions.error && (
         <FormHelperText>
           <HelperText>

--- a/src/components/Contribute/Knowledge/Native/KnowledgeQuestionAnswerPairsNative/KnowledgeQuestionAnswerPairs.tsx
+++ b/src/components/Contribute/Knowledge/Native/KnowledgeQuestionAnswerPairsNative/KnowledgeQuestionAnswerPairs.tsx
@@ -252,7 +252,6 @@ const KnowledgeQuestionAnswerPairsNative: React.FC<Props> = ({
           <div
             style={{
               padding: '10px',
-              // backgroundColor: '#f2f2f2',
               borderRadius: '5px',
               marginBottom: '10px',
               fontSize: '14px',

--- a/src/components/Contribute/Knowledge/Native/index.tsx
+++ b/src/components/Contribute/Knowledge/Native/index.tsx
@@ -490,14 +490,16 @@ export const KnowledgeFormNative: React.FunctionComponent<KnowledgeFormProps> = 
       immutable: true,
       isExpanded: false,
       context: yamlSeedExample.context,
-      // TODO: Hardcoding yaml QnA uploads seed_examples to success until working with Validate.tsx - Bug #465
-      isContextValid: ValidatedOptions.success,
+      isContextValid: ValidatedOptions.default,
+      validationError: '',
       questionAndAnswers: yamlSeedExample.questions_and_answers.map((qa) => ({
         immutable: true,
         question: qa.question,
         answer: qa.answer,
-        isQuestionValid: ValidatedOptions.success,
-        isAnswerValid: ValidatedOptions.success
+        isQuestionValid: ValidatedOptions.default,
+        questionValidationError: '',
+        isAnswerValid: ValidatedOptions.default,
+        answerValidationError: ''
       }))
     }));
 

--- a/src/components/Contribute/Knowledge/UploadFile.tsx
+++ b/src/components/Contribute/Knowledge/UploadFile.tsx
@@ -12,24 +12,38 @@ import {
   Button,
   ModalBody,
   ModalFooter,
-  ModalHeader,
-  ModalVariant
+  ModalHeader
 } from '@patternfly/react-core';
 import { UploadIcon } from '@patternfly/react-icons';
 import React, { useState, useEffect } from 'react';
 import { FileRejection, DropEvent } from 'react-dropzone';
 import './knowledge.css';
 
-interface readFile {
+interface ReadFile {
   fileName: string;
   data?: string;
   loadResult?: 'danger' | 'success';
   loadError?: DOMException;
 }
 
-export const UploadFile: React.FunctionComponent<{ onFilesChange: (files: File[]) => void }> = ({ onFilesChange }) => {
+interface UploadFileProps {
+  onFilesChange: (files: File[]) => void;
+}
+
+// Helper function to convert ArrayBuffer to Base64
+const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
+  let binary = '';
+  const bytes = new Uint8Array(buffer);
+  const len = bytes.byteLength;
+  for (let i = 0; i < len; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return window.btoa(binary);
+};
+
+export const UploadFile: React.FunctionComponent<UploadFileProps> = ({ onFilesChange }) => {
   const [currentFiles, setCurrentFiles] = useState<File[]>([]);
-  const [readFileData, setReadFileData] = useState<readFile[]>([]);
+  const [readFileData, setReadFileData] = useState<ReadFile[]>([]);
   const [showStatus, setShowStatus] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const [statusIcon, setStatusIcon] = useState<'inProgress' | 'success' | 'danger'>('inProgress');
@@ -58,50 +72,172 @@ export const UploadFile: React.FunctionComponent<{ onFilesChange: (files: File[]
     const newReadFiles = readFileData.filter((file) => !namesOfFilesToRemove.includes(file.fileName));
     setCurrentFiles(newCurrentFiles);
     setReadFileData(newReadFiles);
+    onFilesChange(newCurrentFiles); // Also update parent
   };
 
-  const handleFileDrop = (_event: DropEvent, droppedFiles: File[]) => {
+  // Define allowed file types
+  const allowedFileTypes: { [mime: string]: string[] } = {
+    'application/pdf': ['.pdf'],
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': ['.docx'],
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation': ['.pptx'],
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['.xlsx'],
+    'image/*': ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.svg'],
+    'text/html': ['.html'],
+    'text/asciidoc': ['.adoc'],
+    'text/markdown': ['.md']
+  };
+
+  // Convert any file => .md if needed
+  const convertToMarkdownIfNeeded = async (file: File): Promise<File> => {
+    // If user picked a .md file, no need to call the conversion route
+    if (file.name.toLowerCase().endsWith('.md')) {
+      return file;
+    }
+
+    // 1) Read file as ArrayBuffer
+    const arrayBuffer = await new Promise<ArrayBuffer>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result;
+        if (result instanceof ArrayBuffer) {
+          resolve(result);
+        } else {
+          reject(new Error('Unexpected result type when reading file as ArrayBuffer.'));
+        }
+      };
+      reader.onerror = () => {
+        reject(new Error('File reading failed.'));
+      };
+      reader.readAsArrayBuffer(file);
+    });
+
+    // Convert ArrayBuffer to Base64
+    const base64String = arrayBufferToBase64(arrayBuffer);
+
+    // 2) Attempt conversion call
+    try {
+      const res = await fetch('/api/native/convert', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          options: {
+            output_markdown: true,
+            include_images: false
+          },
+          file_source: {
+            base64_string: base64String,
+            filename: file.name
+          }
+        })
+      });
+
+      if (!res.ok) {
+        // Check if it's a 503 => offline service
+        if (res.status === 503) {
+          console.error('Conversion service offline, only .md files accepted');
+          setModalText('The file conversion service is offline. Only Markdown file type can be accepted until service is restored.');
+        } else {
+          console.error(`Conversion service responded with status ${res.status}`);
+          setModalText(`Could not convert file: ${file.name}. Service error: ${res.statusText}`);
+        }
+        throw new Error(`Conversion service responded with non-OK: ${res.status}`);
+      }
+
+      // 3) We expect JSON-wrapped markdown => { content: "..." }
+      const data = await res.json();
+      const mdContent = data.content;
+
+      // 4) Create a new `.md` File object
+      const newName = file.name.replace(/\.[^/.]+$/, '') + '.md';
+      const mdBlob = new Blob([mdContent], { type: 'text/markdown' });
+      const mdFile = new File([mdBlob], newName, { type: 'text/markdown' });
+      return mdFile;
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error('Conversion error:', error);
+        // If conversion fails, we let the UI know
+        throw error;
+      } else {
+        console.error('Unknown conversion error:', error);
+        throw new Error('An unknown error occurred during file conversion.');
+      }
+    }
+  };
+
+  // Handle drop (and re-drop) of files
+  const handleFileDrop = async (_event: DropEvent, droppedFiles: File[]) => {
     setIsUploading(true);
+    setStatusIcon('inProgress');
+
     const currentFileNames = currentFiles.map((file) => file.name);
     const reUploads = droppedFiles.filter((file) => currentFileNames.includes(file.name));
 
-    const newFiles = [
-      ...currentFiles.filter((file) => !reUploads.includes(file)),
-      ...droppedFiles.filter((file) => !currentFileNames.includes(file.name))
-    ];
-    setCurrentFiles(newFiles);
-    onFilesChange(newFiles);
+    // Keep existing files that are not about to be re-uploaded
+    const newFilesArr = currentFiles.filter((file) => !reUploads.includes(file));
+
+    // Convert new or replaced files to .md if needed
+    for (const f of droppedFiles) {
+      if (!currentFileNames.includes(f.name)) {
+        try {
+          const convertedFile = await convertToMarkdownIfNeeded(f);
+          newFilesArr.push(convertedFile);
+        } catch (err) {
+          if (err instanceof Error) {
+            console.error('File conversion failed for:', f.name, err);
+            setModalText(`Could not convert file: ${f.name}. ${err.message}`);
+          } else {
+            console.error('File conversion failed for:', f.name, err);
+            setModalText(`Could not convert file: ${f.name}. An unknown error occurred.`);
+          }
+        }
+      } else {
+        // user re-uploaded the same file name
+        // remove the old one, and try to convert the new one
+        const index = newFilesArr.findIndex((ef) => ef.name === f.name);
+        if (index !== -1) {
+          newFilesArr.splice(index, 1);
+        }
+        try {
+          const convertedFile = await convertToMarkdownIfNeeded(f);
+          newFilesArr.push(convertedFile);
+        } catch (err) {
+          console.error('Re-upload conversion failed for file:', f.name, err);
+          setModalText(`Could not convert file: ${f.name}. Check console for details, or try again later.`);
+        }
+      }
+    }
+
+    // Update states
+    setCurrentFiles(newFilesArr);
+    onFilesChange(newFilesArr);
+    setIsUploading(false);
   };
 
   const handleReadSuccess = (data: string, file: File) => {
-    setReadFileData((prevReadFiles) => {
-      const existingFile = prevReadFiles.find((readFile) => readFile.fileName === file.name);
-      if (existingFile) {
-        return prevReadFiles;
+    setReadFileData((prev) => {
+      // If we have an existing entry for that file, skip
+      if (prev.find((readFile) => readFile.fileName === file.name)) {
+        return prev;
       }
-      setIsUploading(false);
-      return [...prevReadFiles, { data, fileName: file.name, loadResult: 'success' }];
+      return [...prev, { data, fileName: file.name, loadResult: 'success' }];
     });
   };
 
   const handleReadFail = (error: DOMException, file: File) => {
-    setReadFileData((prevReadFiles) => {
-      const existingFile = prevReadFiles.find((readFile) => readFile.fileName === file.name);
-      if (existingFile) {
-        return prevReadFiles;
+    setReadFileData((prev) => {
+      // If we have an existing entry for that file, skip
+      if (prev.find((readFile) => readFile.fileName === file.name)) {
+        return prev;
       }
-      return [...prevReadFiles, { loadError: error, fileName: file.name, loadResult: 'danger' }];
+      return [...prev, { loadError: error, fileName: file.name, loadResult: 'danger' }];
     });
   };
 
   const handleDropRejected = (fileRejections: FileRejection[]) => {
-    console.warn('Files rejected:', fileRejections);
-    if (fileRejections.length === 1) {
-      setModalText(`${fileRejections[0].file.name} is not an accepted file type. Please upload a Markdown file.`);
-    } else {
-      const rejectedMessages = fileRejections.reduce((acc, fileRejection) => (acc += `${fileRejection.file.name}, `), '');
-      setModalText(`${rejectedMessages} are not accepted file types. Please upload Markdown files.`);
-    }
+    console.warn('Files were rejected:', fileRejections);
+    setModalText(
+      'Some files were rejected. Please ensure you are uploading files with the following extensions: PDF, DOCX, PPTX, XLSX, Images, HTML, AsciiDoc & Markdown.'
+    );
   };
 
   const createHelperText = (file: File) => {
@@ -122,9 +258,7 @@ export const UploadFile: React.FunctionComponent<{ onFilesChange: (files: File[]
       <MultipleFileUpload
         onFileDrop={handleFileDrop}
         dropzoneProps={{
-          accept: {
-            'text/markdown': ['.md']
-          },
+          accept: allowedFileTypes,
           onDropRejected: handleDropRejected
         }}
       >
@@ -132,21 +266,25 @@ export const UploadFile: React.FunctionComponent<{ onFilesChange: (files: File[]
           titleIcon={<UploadIcon />}
           titleText="Drag and drop files here"
           titleTextSeparator="or"
-          infoText="Accepted file types: Markdown"
+          infoText={
+            <>
+              Accepted file types: PDF, DOCX, PPTX, XLSX, Images, HTML, AsciiDoc & Markdown.
+              <br />
+              Non-Markdown files will be automatically converted to Markdown for context selection.
+            </>
+          }
         />
         <div className="spinner-container">
           {isUploading && (
             <>
               <Spinner size="lg" />
-              <p>
-                Uploading files to <code>taxonomy-knowledge-docs</code> repo.
-              </p>
+              <p>Uploading and converting files to Markdown file format…</p>
             </>
           )}
         </div>
         {showStatus && (
           <MultipleFileUploadStatus
-            statusToggleText={`${successfullyReadFileCount} of ${currentFiles.length} files uploaded`}
+            statusToggleText={`${successfullyReadFileCount} of ${currentFiles.length} files processed`}
             statusToggleIcon={statusIcon}
             aria-label="Current uploads"
           >
@@ -163,9 +301,10 @@ export const UploadFile: React.FunctionComponent<{ onFilesChange: (files: File[]
           </MultipleFileUploadStatus>
         )}
         <Modal
-          variant={ModalVariant.small}
-          title="Unsupported file"
           isOpen={!!modalText}
+          title="File Conversion Issue"
+          variant="small"
+          aria-label="file conversion error"
           onClose={() => setModalText('')}
           aria-labelledby="unsupported-file-modal-title"
           aria-describedby="unsupported-file-body-variant"


### PR DESCRIPTION
- Integrates an automated file conversion via docling-serve to the native knowledge submission component.
- Supports the docling conversion file types of PDF, DOCX, PPTX, XLSX, Images, HTML and AsciiDoc to be used in the next step of context selection (see demo vid below).
- There is a health check of docling-serve at file upload selection, if the service is unavailable, only md files are accepted.

This depends on #439. That PRs changes are in this PR to spare myself another rebase. Will leave this in draft until 439 merges.

Demo .pptx conversion:

https://github.com/user-attachments/assets/e7558b59-79e5-4d48-a23d-877000c7d94d

Demo Image conversion:

https://github.com/user-attachments/assets/d4211702-c23b-4488-8455-fa52cc3e42e4


