### PR TITLE
Change the context limit from characters to words

### DIFF
--- a/.env.github.example
+++ b/.env.github.example
@@ -1,3 +1,5 @@
+IL_UI_ADMIN_USERNAME=admin # user/pass for dev mode
+IL_UI_ADMIN_PASSWORD=password
 IL_UI_DEPLOYMENT=github # Start UI stack in github mode.
 OAUTH_GITHUB_ID=<OAUTH_APP_ID>
 OAUTH_GITHUB_SECRET=<OAUTH_APP_SECRET>

--- a/src/components/Contribute/Knowledge/KnowledgeQuestionAnswerPairs/KnowledgeQuestionAnswerPairs.tsx
+++ b/src/components/Contribute/Knowledge/KnowledgeQuestionAnswerPairs/KnowledgeQuestionAnswerPairs.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { KnowledgeSeedExample, QuestionAndAnswerPair } from '@/types';
 import { FormGroup, TextArea, ValidatedOptions, FormHelperText, HelperText, HelperTextItem, FormFieldGroupHeader } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
@@ -24,6 +24,30 @@ const KnowledgeQuestionAnswerPairs: React.FC<Props> = ({
   handleAnswerInputChange,
   handleAnswerBlur
 }) => {
+  const [contextWordCount, setContextWordCount] = useState(0);
+  const MAX_WORDS = 500;
+
+  // TODO: replace with a tokenizer library
+  const countWords = (text: string) => {
+    return text.trim().split(/\s+/).filter(Boolean).length;
+  };
+
+  // Update word count whenever context changes
+  useEffect(() => {
+    setContextWordCount(countWords(seedExample.context));
+  }, [seedExample.context]);
+
+  // Handle context input change with word count validation
+  const onContextChange = (_event: React.FormEvent<HTMLTextAreaElement>, contextValue: string) => {
+    const wordCount = countWords(contextValue);
+    if (wordCount <= MAX_WORDS) {
+      handleContextInputChange(seedExampleIndex, contextValue);
+    } else {
+      // allow the overage and show validation error
+      handleContextInputChange(seedExampleIndex, contextValue);
+    }
+  };
+
   return (
     <FormGroup key={seedExampleIndex}>
       <TextArea
@@ -34,10 +58,19 @@ const KnowledgeQuestionAnswerPairs: React.FC<Props> = ({
         placeholder="Enter the context from which the Q&A pairs are derived. (500 words max)"
         value={seedExample.context}
         validated={seedExample.isContextValid}
-        maxLength={500}
-        onChange={(_event, contextValue: string) => handleContextInputChange(seedExampleIndex, contextValue)}
+        onChange={onContextChange}
         onBlur={() => handleContextBlur(seedExampleIndex)}
       />
+
+      {/* Display word count */}
+      <FormHelperText>
+        <HelperText>
+          <HelperTextItem>
+            {contextWordCount} / {MAX_WORDS} words
+          </HelperTextItem>
+        </HelperText>
+      </FormHelperText>
+
       {seedExample.isContextValid === ValidatedOptions.error && (
         <FormHelperText key={seedExampleIndex * 10 + 2}>
           <HelperText>


### PR DESCRIPTION
- Was checking character counts instead of word counts.
- Also adds a counter for the user to see when over and how much.
- Added user/pass for dev mode in the GitHub env.example.

@vishnoianil Also `npm run pretty` changed a bunch of formatting so I think a PR slid in that didn't get prettied or another version ¯\_(ツ)_/¯ I think that was on me for merging the import cleanups.

Closes #462 

<img width="643" alt="image" src="https://github.com/user-attachments/assets/88b5c15a-3d45-4b51-83e4-843f19e371c9" />
