### PR TITLE
Bug fix: fix the knowledge doc repo path and repo url/path validation

### DIFF
--- a/src/components/Contribute/Knowledge/Native/DocumentInformation/DocumentInformation.tsx
+++ b/src/components/Contribute/Knowledge/Native/DocumentInformation/DocumentInformation.tsx
@@ -268,7 +268,8 @@ const DocumentInformation: React.FC<Props> = ({
           <FormGroup isRequired key={'doc-info-details-id'} label="Repo URL or Server Side File Path">
             <TextInput
               isRequired
-              type="url"
+              // TODO: once all of the different potential filepaths/url/types are determined, add back stricter validation
+              type="text"
               aria-label="repo"
               validated={validRepo}
               placeholder="Enter repo URL where document exists"

--- a/src/components/Contribute/Knowledge/Native/KnowledgeQuestionAnswerPairsNative/KnowledgeQuestionAnswerPairs.tsx
+++ b/src/components/Contribute/Knowledge/Native/KnowledgeQuestionAnswerPairsNative/KnowledgeQuestionAnswerPairs.tsx
@@ -65,7 +65,7 @@ const KnowledgeQuestionAnswerPairsNative: React.FC<Props> = ({
   const preRefs = useRef<Record<string, HTMLPreElement | null>>({});
 
   const LOCAL_TAXONOMY_DOCS_ROOT_DIR =
-    process.env.NEXT_PUBLIC_LOCAL_TAXONOMY_DOCS_ROOT_DIR || '/home/yourusername/.instructlab-ui/taxonomy-knowledge-docs';
+    `${process.env.NEXT_PUBLIC_LOCAL_TAXONOMY_ROOT_DIR}/taxonomy-knowledge-docs` || `${process.env.HOME}/.instructlab-ui/taxonomy-knowledge-docs`;
 
   const fetchKnowledgeFiles = async () => {
     setIsLoading(true);


### PR DESCRIPTION
- Native submissions neeed /taxonomy-knowledge-docs appended  to the path after NEXT_PUBLIC_LOCAL_TAXONOMY_ROOT_DIR
- Since knowledge docs are not just a URL, change the validation to text instead of url.