### PR TITLE
allow images to be overrideable via args

### DIFF
--- a/pathservice/Containerfile
+++ b/pathservice/Containerfile
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.22.5-1730550521 AS builder
+ARG BUILDER_IMAGE="registry.access.redhat.com/ubi9/go-toolset:1.22.5-1730550521"
+
+FROM ${BUILDER_IMAGE} AS builder
 
 WORKDIR /opt/app-root/src
 
@@ -8,7 +10,9 @@ COPY ./pathservice ./
 RUN go build -o bin/pathservice
 
 # Start a new stage from scratch
-FROM registry.access.redhat.com/ubi9-micro:9.5-1731934928
+ARG BASE_IMAGE="registry.access.redhat.com/ubi9-micro:9.5-1731934928"
+
+FROM ${BASE_IMAGE}
 
 # Copy the binary from the previous stage
 COPY --from=builder /opt/app-root/src/bin/pathservice /pathservice

--- a/src/Containerfile
+++ b/src/Containerfile
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi9/nodejs-22:9.5-1730543890
+ARG BASE_IMAGE="registry.access.redhat.com/ubi9/nodejs-22:9.5-1730543890"
+
+FROM ${BASE_IMAGE}
 
 USER root
 


### PR DESCRIPTION
cc @nerdalert and @vishnoianil, this is how downstream will override the `registry.access.redhat.io` images with `registry.redhat.io` `rhel` based images