### PR TITLE
Add any served models in a column in the jobs table

### DIFF
--- a/api-server/.gitignore
+++ b/api-server/.gitignore
@@ -21,6 +21,9 @@ go.work.sum
 # env file
 .env
 
+# binary
+api-server
+
 # app specific
 logs/
 jobs.json


### PR DESCRIPTION
Enables the user to leave and return to the model chat eval without having launch a new job, instead use the existing job for either pre-train or post-train.