### PR TITLE
potential fix for the cherry pick git actions workflow error

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Cherry-pick commit
         run: |
           git checkout release-1.0
-          git cherry-pick ${{ github.event.pull_request.merge_commit_sha }}
+          git cherry-pick -m 1 ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
<img width="845" alt="image" src="https://github.com/user-attachments/assets/8803b273-b732-4500-9017-5c182a975947" />


The `-m 1`  option should tell Git to use the first parent of the merge commit as the mainline. Typically the target branch of the original pull request.