### PR TITLE
Fixes DCO signoff issue

### DIFF
--- a/src/components/Contribute/Knowledge/index.tsx
+++ b/src/components/Contribute/Knowledge/index.tsx
@@ -5,7 +5,7 @@ import './knowledge.css';
 import { Alert, AlertActionCloseButton } from '@patternfly/react-core/dist/dynamic/components/Alert';
 import { ActionGroup } from '@patternfly/react-core/dist/dynamic/components/Form';
 import { Form } from '@patternfly/react-core/dist/dynamic/components/Form';
-import { getGitHubUsername } from '../../../utils/github';
+import { getGitHubUserInfo } from '../../../utils/github';
 import { useSession } from 'next-auth/react';
 import AuthorInformation from '../AuthorInformation';
 import { FormType } from '../AuthorInformation';
@@ -178,15 +178,8 @@ export const KnowledgeForm: React.FunctionComponent<KnowledgeFormProps> = ({ kno
     getEnvVariables();
   }, []);
 
-  useEffect(() => {
-    if (session?.user?.name && session?.user?.email) {
-      setName(session?.user?.name);
-      setEmail(session?.user?.email);
-    }
-  }, [session?.user]);
-
   useMemo(() => {
-    const fetchUsername = async () => {
+    const fetchUserInfo = async () => {
       if (session?.accessToken) {
         try {
           const headers = {
@@ -196,15 +189,17 @@ export const KnowledgeForm: React.FunctionComponent<KnowledgeFormProps> = ({ kno
             'X-GitHub-Api-Version': '2022-11-28'
           };
 
-          const fetchedUsername = await getGitHubUsername(headers);
-          setGithubUsername(fetchedUsername);
+          const fetchedUsername = await getGitHubUserInfo(headers);
+          setGithubUsername(fetchedUsername.login);
+          setName(fetchedUsername.name);
+          setEmail(fetchedUsername.email);
         } catch (error) {
-          console.error('Failed to fetch GitHub username:', error);
+          console.error('Failed to fetch GitHub user info:', error);
         }
       }
     };
 
-    fetchUsername();
+    fetchUserInfo();
   }, [session?.accessToken]);
 
   useEffect(() => {

--- a/src/components/Contribute/Knowledge/knowledge.css
+++ b/src/components/Contribute/Knowledge/knowledge.css
@@ -23,7 +23,7 @@
   border-color: #45a049;
 }
 
-.spinner-container{
+.spinner-container {
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/Contribute/Skill/index.tsx
+++ b/src/components/Contribute/Skill/index.tsx
@@ -5,7 +5,7 @@ import './skills.css';
 import { Alert, AlertActionCloseButton } from '@patternfly/react-core/dist/dynamic/components/Alert';
 import { ActionGroup } from '@patternfly/react-core/dist/dynamic/components/Form';
 import { Form } from '@patternfly/react-core/dist/dynamic/components/Form';
-import { getGitHubUsername } from '../../../utils/github';
+import { getGitHubUserInfo } from '../../../utils/github';
 import { useSession } from 'next-auth/react';
 import AuthorInformation from '../AuthorInformation';
 import { FormType } from '../AuthorInformation';
@@ -139,32 +139,28 @@ export const SkillForm: React.FunctionComponent<SkillFormProps> = ({ skillEditFo
     getEnvVariables();
   }, []);
 
-  useEffect(() => {
-    if (session?.user?.name && session?.user?.email) {
-      setName(session?.user?.name);
-      setEmail(session?.user?.email);
-    }
-  }, [session?.user]);
-
   useMemo(() => {
-    const fetchUsername = async () => {
+    const fetchUserInfo = async () => {
       if (session?.accessToken) {
         try {
-          const header = {
+          const headers = {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${session.accessToken}`,
             Accept: 'application/vnd.github+json',
             'X-GitHub-Api-Version': '2022-11-28'
           };
-          const fetchedUsername = await getGitHubUsername(header);
-          setGithubUsername(fetchedUsername);
+
+          const fetchedUsername = await getGitHubUserInfo(headers);
+          setGithubUsername(fetchedUsername.login);
+          setName(fetchedUsername.name);
+          setEmail(fetchedUsername.email);
         } catch (error) {
-          console.error('Failed to fetch GitHub username:', error);
+          console.error('Failed to fetch GitHub user info:', error);
         }
       }
     };
 
-    fetchUsername();
+    fetchUserInfo();
   }, [session?.accessToken]);
 
   useEffect(() => {


### PR DESCRIPTION
Auth session keeps information from the user profile, so if the email address is not made visible on the profile or alias is set as an email address, UI was using that email address for signoff. In some cases, this was failing because that email address is not users primary email address.

For DCO to pass, user needs to signoff the commits with it's primary email address set in his account.
