### PR TITLE
Fixes DCO signoff issue

### DIFF
--- a/src/components/Contribute/EditKnowledge/github/EditKnowledge.tsx
+++ b/src/components/Contribute/EditKnowledge/github/EditKnowledge.tsx
@@ -1,4 +1,4 @@
-// src/app/edit-submission/knowledge/[id]/page.tsx
+// src/app/components/contribute/EditKnowledge/github/EditKnowledge.tsx
 'use client';
 
 import * as React from 'react';

--- a/src/components/Contribute/EditKnowledge/native/EditKnowledge.tsx
+++ b/src/components/Contribute/EditKnowledge/native/EditKnowledge.tsx
@@ -1,4 +1,4 @@
-// src/app/edit-submission/knowledge/native/[id]/EditKnowledge.tsx
+// src/app/components/contribute/EditKnowledge/native/EditKnowledge.tsx
 'use client';
 
 import * as React from 'react';

--- a/src/components/Contribute/EditSkill/github/EditSkill.tsx
+++ b/src/components/Contribute/EditSkill/github/EditSkill.tsx
@@ -1,4 +1,4 @@
-// src/app/edit-submission/skill/[id]/EditSkillClientComponent.tsx
+// src/app/components/contribute/EditSkill/github/EditSkill.tsx
 'use client';
 
 import * as React from 'react';

--- a/src/components/Contribute/EditSkill/native/EditSkill.tsx
+++ b/src/components/Contribute/EditSkill/native/EditSkill.tsx
@@ -1,4 +1,4 @@
-// src/app/edit-submission/skill/native/[id]/EditSkill.tsx
+// src/app/components/contribute/EditSkill/native/EditSkill.tsx
 'use client';
 
 import * as React from 'react';

--- a/src/components/Contribute/Knowledge/Github/index.tsx
+++ b/src/components/Contribute/Knowledge/Github/index.tsx
@@ -2,7 +2,7 @@
 'use client';
 import React, { useEffect, useMemo, useState } from 'react';
 import '../knowledge.css';
-import { getGitHubUsername } from '@/utils/github';
+import { getGitHubUserInfo } from '@/utils/github';
 import { useSession } from 'next-auth/react';
 import AuthorInformation from '@/components/Contribute/AuthorInformation';
 import { FormType } from '@/components/Contribute/AuthorInformation';
@@ -153,15 +153,8 @@ export const KnowledgeFormGithub: React.FunctionComponent<KnowledgeFormProps> = 
     getEnvVariables();
   }, []);
 
-  useEffect(() => {
-    if (session?.user?.name && session?.user?.email) {
-      setName(session?.user?.name);
-      setEmail(session?.user?.email);
-    }
-  }, [session?.user]);
-
   useMemo(() => {
-    const fetchUsername = async () => {
+    const fetchUserInfo = async () => {
       if (session?.accessToken) {
         try {
           const headers = {
@@ -171,15 +164,17 @@ export const KnowledgeFormGithub: React.FunctionComponent<KnowledgeFormProps> = 
             'X-GitHub-Api-Version': '2022-11-28'
           };
 
-          const fetchedUsername = await getGitHubUsername(headers);
-          setGithubUsername(fetchedUsername);
+          const fetchedUserInfo = await getGitHubUserInfo(headers);
+          setGithubUsername(fetchedUserInfo.login);
+          setName(fetchedUserInfo.name);
+          setEmail(fetchedUserInfo.email);
         } catch (error) {
-          console.error('Failed to fetch GitHub username:', error);
+          console.error('Failed to fetch GitHub user info:', error);
         }
       }
     };
 
-    fetchUsername();
+    fetchUserInfo();
   }, [session?.accessToken]);
 
   useEffect(() => {
@@ -523,7 +518,6 @@ export const KnowledgeFormGithub: React.FunctionComponent<KnowledgeFormProps> = 
   };
 
   const onYamlUploadKnowledgeFillForm = (data: KnowledgeYamlData): void => {
-    setName(data.created_by ?? '');
     setDocumentOutline(data.document_outline ?? '');
     setSubmissionSummary(data.document_outline ?? '');
     setDomain(data.domain ?? '');

--- a/src/components/Contribute/Skill/Github/index.tsx
+++ b/src/components/Contribute/Skill/Github/index.tsx
@@ -2,7 +2,7 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import '../skills.css';
-import { getGitHubUsername } from '../../../../utils/github';
+import { getGitHubUserInfo } from '../../../../utils/github';
 import { useSession } from 'next-auth/react';
 import FilePathInformation from '../FilePathInformation/FilePathInformation';
 import AttributionInformation from '../AttributionInformation/AttributionInformation';
@@ -122,14 +122,7 @@ export const SkillFormGithub: React.FunctionComponent<SkillFormProps> = ({ skill
   }, []);
 
   useEffect(() => {
-    if (session?.user?.name && session?.user?.email) {
-      setName(session?.user?.name);
-      setEmail(session?.user?.email);
-    }
-  }, [session?.user]);
-
-  useEffect(() => {
-    const fetchUsername = async () => {
+    const fetchUserInfo = async () => {
       if (session?.accessToken) {
         try {
           const headers = {
@@ -139,15 +132,17 @@ export const SkillFormGithub: React.FunctionComponent<SkillFormProps> = ({ skill
             'X-GitHub-Api-Version': '2022-11-28'
           };
 
-          const fetchedUsername = await getGitHubUsername(headers);
-          setGithubUsername(fetchedUsername);
+          const fetchedUserInfo = await getGitHubUserInfo(headers);
+          setGithubUsername(fetchedUserInfo.login);
+          setName(fetchedUserInfo.name);
+          setEmail(fetchedUserInfo.email);
         } catch (error) {
-          console.error('Failed to fetch GitHub username:', error);
+          console.error('Failed to fetch GitHub user info:', error);
         }
       }
     };
 
-    fetchUsername();
+    fetchUserInfo();
   }, [session?.accessToken]);
 
   useEffect(() => {
@@ -331,7 +326,6 @@ export const SkillFormGithub: React.FunctionComponent<SkillFormProps> = ({ skill
   };
 
   const onYamlUploadSkillsFillForm = (data: SkillYamlData): void => {
-    setName(data.created_by ?? '');
     setDocumentOutline(data.task_description ?? '');
     setSeedExamples(yamlSeedExampleToFormSeedExample(data.seed_examples));
   };

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -3,6 +3,12 @@ import axios from 'axios';
 import { PullRequestUpdateData } from '@/types';
 import { BASE_BRANCH, FORK_CLONE_CHECK_RETRY_COUNT, FORK_CLONE_CHECK_RETRY_TIMEOUT, GITHUB_API_URL } from '@/types/const';
 
+type GithubUserInfo = {
+  login: string;
+  name: string;
+  email: string;
+};
+
 export async function fetchPullRequests(token: string) {
   try {
     console.log('Refreshing PR Listing');
@@ -297,6 +303,28 @@ export const amendCommit = async (
     throw error;
   }
 };
+export async function getGitHubUserInfo(headers: HeadersInit): Promise<GithubUserInfo> {
+  const response = await fetch(`${GITHUB_API_URL}/user`, {
+    headers
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('Failed to fetch GitHub user info:', response.status, errorText);
+    throw new Error('Failed to fetch GitHub user info');
+  }
+
+  const data = await response.json();
+
+  const userInfo: GithubUserInfo = {
+    name: data.name,
+    login: data.login,
+    email: ''
+  };
+
+  userInfo.email = await getGitHubUserPrimaryEmail(headers);
+  return userInfo;
+}
 
 export async function getGitHubUsername(headers: HeadersInit): Promise<string> {
   const response = await fetch(`${GITHUB_API_URL}/user`, {
@@ -311,6 +339,22 @@ export async function getGitHubUsername(headers: HeadersInit): Promise<string> {
 
   const data = await response.json();
   return data.login;
+}
+
+export async function getGitHubUserPrimaryEmail(headers: HeadersInit): Promise<string> {
+  const response = await fetch(`${GITHUB_API_URL}/user/public_emails`, {
+    headers
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('Failed to fetch GitHub email address:', response.status, errorText);
+    throw new Error('Failed to fetch GitHub email address');
+  }
+
+  const data = await response.json();
+  const emailInfo = data.find((emailObj: { primary: boolean }) => emailObj.primary === true);
+  return emailInfo.email;
 }
 
 export async function createFork(headers: HeadersInit, upstreamRepoOwner: string, upstreamRepoName: string, username: string) {


### PR DESCRIPTION
Auth session keeps information from the user profile,
so if the email address is not made visible on the profile
or alias is set as an email address, UI was using that email
address for signoff. In some cases, this was failing because
that email address is not users primary email address.

For DCO to pass, user needs to signoff the commits with it's
primary email address set in his account.