### PR TITLE
User the release-alpha image that uses the old docling api

### DIFF
--- a/deploy/podman/native/instructlab-ui.yaml
+++ b/deploy/podman/native/instructlab-ui.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: doclingserve
-        image: ghcr.io/ds4sd/docling-serve-cpu:main
+        image: ghcr.io/ds4sd/docling-serve-cpu:release-alpha
         ports:
         - containerPort: 5001
           hostPort: 5001


### PR DESCRIPTION
Once UI moves to new docling-serve api's, docling-serve latest image can be used.