### PR TITLE
Allow for null values in GH account responses

### DIFF
--- a/src/components/Contribute/Knowledge/Github/index.tsx
+++ b/src/components/Contribute/Knowledge/Github/index.tsx
@@ -1,6 +1,6 @@
 // src/components/Contribute/Knowledge/Github/index.tsx
 'use client';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import '../knowledge.css';
 import { getGitHubUserInfo } from '@/utils/github';
 import { useSession } from 'next-auth/react';
@@ -153,7 +153,7 @@ export const KnowledgeFormGithub: React.FunctionComponent<KnowledgeFormProps> = 
     getEnvVariables();
   }, []);
 
-  useMemo(() => {
+  useEffect(() => {
     const fetchUserInfo = async () => {
       if (session?.accessToken) {
         try {


### PR DESCRIPTION
- Github doesn't require names to be added to an account. This avoids throwing an error if a name is not present.
- Emails on GH account can be private. Permit the email field to be empty as well.