### PR TITLE
Native mode ENV updates

### DIFF
--- a/.env.native.example
+++ b/.env.native.example
@@ -11,6 +11,6 @@ NEXT_PUBLIC_TAXONOMY_ROOT_DIR=
 
 NEXT_PUBLIC_EXPERIMENTAL_FEATURES=false
 
-# IL_FILE_CONVERSION_SERVICE=http://localhost:8000 # Uncomment and fill in the http://host:port if the docling conversion service is running.
+# IL_FILE_CONVERSION_SERVICE=http://localhost:5001 # Uncomment and fill in the http://host:port if the docling conversion service is running.
 # NEXT_PUBLIC_API_SERVER=http://localhost:8080 # Uncomment and point to the URL the api-server is running on. Native mode only and needs to be running on the same host as the UI.
 # NEXT_PUBLIC_MODEL_SERVER_URL=http://x.x.x.x # Used for model chat evaluation vLLM instances. Currently, server side rendering is not supported so the client must have access to this address for model chat evaluation to function in the UI. Currently ports, 8000 & 8001 are hardcoded and why it is not an option to set.

--- a/.env.native.example
+++ b/.env.native.example
@@ -7,7 +7,7 @@ NEXTAUTH_URL=http://localhost:3000
 IL_UI_DEPLOYMENT=native # Two deployment modes are available: github and native
 IL_ENABLE_DEV_MODE=true #Enable this option if you want to enable UI features that helps in development, such as form Auto-Fill feature.
 
-NEXT_PUBLIC_TAXONOMY_ROOT_DIR=
+NEXT_PUBLIC_TAXONOMY_ROOT_DIR= # Required value. Recommended /<INSERT_HOME_DIRECTORY_PATH>/.instructlab-ui
 
 NEXT_PUBLIC_EXPERIMENTAL_FEATURES=false
 


### PR DESCRIPTION
- Change from 8000 to 5001 per the current docling-serve default port for the service.
- Add a comment to `NEXT_PUBLIC_TAXONOMY_ROOT_DIR` that it is a required field. Cannot make it dynamic at the moment since it conflicts with the container deployment otherwise.