### PR TITLE
Fix for resetting to edit data in github mode

### DIFF
--- a/src/components/Contribute/EditKnowledge/github/EditKnowledge.tsx
+++ b/src/components/Contribute/EditKnowledge/github/EditKnowledge.tsx
@@ -143,7 +143,7 @@ const EditKnowledge: React.FC<EditKnowledgeClientComponentProps> = ({ prNumber }
       }
     };
     fetchPRData();
-  }, [session, prNumber]);
+  }, [session?.accessToken, prNumber]);
 
   const parseAttributionContent = (content: string): AttributionData => {
     const lines = content.split('\n');

--- a/src/components/Contribute/EditSkill/github/EditSkill.tsx
+++ b/src/components/Contribute/EditSkill/github/EditSkill.tsx
@@ -123,7 +123,7 @@ const EditSkill: React.FC<EditSkillClientComponentProps> = ({ prNumber }) => {
       }
     };
     fetchPRData();
-  }, [session, prNumber]);
+  }, [session?.accessToken, prNumber]);
 
   const parseAttributionContent = (content: string): AttributionData => {
     const lines = content.split('\n');


### PR DESCRIPTION
## Description
When editing a contribution in github mode, if the user loses focus from the current window and then comes back, any edits made are lost.

Update the dependencies that fetch the edit data and update the form to be more specific so that it isn't recreated unless the real data changed.