### PR TITLE
Fix for showing context files for the first seed example and filling context from selection

### DIFF
--- a/src/components/Contribute/Knowledge/KnowledgeSeedExamples/KnowledgeSeedExamples.tsx
+++ b/src/components/Contribute/Knowledge/KnowledgeSeedExamples/KnowledgeSeedExamples.tsx
@@ -68,7 +68,7 @@ const KnowledgeSeedExamples: React.FC<Props> = ({ isGithubMode, seedExamples, on
       }
     };
 
-    if (fileSelectIndex > 0 && !knowledgeFiles.length) {
+    if (fileSelectIndex >= 0 && !knowledgeFiles.length) {
       fetchKnowledgeFiles();
     }
   }, [fileSelectIndex, isGithubMode, knowledgeFiles.length]);
@@ -78,7 +78,7 @@ const KnowledgeSeedExamples: React.FC<Props> = ({ isGithubMode, seedExamples, on
   };
 
   const handleSelectContextInput = (contextValue: string) => {
-    handleKnowledgeSeedExamplesContextInputChange(seedExamples, fileSelectIndex, contextValue, true);
+    onUpdateSeedExamples(handleKnowledgeSeedExamplesContextInputChange(seedExamples, fileSelectIndex, contextValue, true));
   };
 
   const handleContextBlur = (seedExampleIndex: number): void => {

--- a/src/components/Contribute/Knowledge/KnowledgeWizard/KnowledgeWizard.tsx
+++ b/src/components/Contribute/Knowledge/KnowledgeWizard/KnowledgeWizard.tsx
@@ -67,36 +67,31 @@ const STEP_IDS = ['author-info', 'knowledge-info', 'file-path-info', 'document-i
 
 export const KnowledgeWizard: React.FunctionComponent<KnowledgeFormProps> = ({ knowledgeEditFormData, isGithubMode }) => {
   const { data: session } = useSession();
-  const [knowledgeFormData, setKnowledgeFormData] = React.useState<KnowledgeFormData>(knowledgeEditFormData?.formData || DefaultKnowledgeFormData);
+  const [knowledgeFormData, setKnowledgeFormData] = React.useState<KnowledgeFormData>(
+    knowledgeEditFormData?.formData
+      ? {
+          ...knowledgeEditFormData.formData,
+          seedExamples: knowledgeEditFormData.formData.seedExamples.map((example) => ({
+            ...example,
+            immutable: example.immutable !== undefined ? example.immutable : true, // Ensure immutable is set
+            isContextValid: example.isContextValid || ValidatedOptions.default,
+            validationError: example.validationError || '',
+            questionAndAnswers: example.questionAndAnswers.map((qa) => ({
+              ...qa,
+              immutable: qa.immutable !== undefined ? qa.immutable : true, // Ensure immutable is set
+              isQuestionValid: qa.isQuestionValid || ValidatedOptions.default,
+              questionValidationError: qa.questionValidationError || '',
+              isAnswerValid: qa.isAnswerValid || ValidatedOptions.default,
+              answerValidationError: qa.answerValidationError || ''
+            }))
+          }))
+        }
+      : DefaultKnowledgeFormData
+  );
   const [actionGroupAlertContent, setActionGroupAlertContent] = useState<ActionGroupAlertContent | undefined>();
   const [isYamlModalOpen, setIsYamlModalOpen] = useState<boolean>(false); // **New State Added**
 
   const router = useRouter();
-
-  useEffect(() => {
-    // Set all elements from the knowledgeFormData to the state
-    if (knowledgeEditFormData) {
-      setKnowledgeFormData({
-        ...knowledgeEditFormData.formData,
-        seedExamples: knowledgeEditFormData.formData.seedExamples.map((example) => ({
-          ...example,
-          immutable: example.immutable !== undefined ? example.immutable : true, // Ensure immutable is set
-          isContextValid: example.isContextValid || ValidatedOptions.default,
-          validationError: example.validationError || '',
-          questionAndAnswers: example.questionAndAnswers.map((qa) => ({
-            ...qa,
-            immutable: qa.immutable !== undefined ? qa.immutable : true, // Ensure immutable is set
-            isQuestionValid: qa.isQuestionValid || ValidatedOptions.default,
-            questionValidationError: qa.questionValidationError || '',
-            isAnswerValid: qa.isAnswerValid || ValidatedOptions.default,
-            answerValidationError: qa.answerValidationError || ''
-          }))
-        }))
-      });
-
-      devLog('Seed Examples Set from Edit Form Data:', knowledgeEditFormData.formData.seedExamples);
-    }
-  }, [knowledgeEditFormData]);
 
   // Function to append document information (Updated for single repositoryUrl and commitSha)
   // Within src/components/Contribute/Native/index.tsx

--- a/src/components/Contribute/Skill/SkillWizard/SkillWizard.tsx
+++ b/src/components/Contribute/Skill/SkillWizard/SkillWizard.tsx
@@ -57,35 +57,31 @@ const STEP_IDS = ['author-info', 'skill-info', 'file-path-info', 'document-info'
 
 export const SkillWizard: React.FunctionComponent<Props> = ({ skillEditFormData, isGithubMode }) => {
   const { data: session } = useSession();
-  const [skillFormData, setSkillFormData] = React.useState<SkillFormData>(skillEditFormData?.formData || DefaultSkillFormData);
+  const [skillFormData, setSkillFormData] = React.useState<SkillFormData>(
+    skillEditFormData?.formData
+      ? {
+          ...skillEditFormData.formData,
+          seedExamples: skillEditFormData.formData.seedExamples.map((example) => ({
+            ...example,
+            immutable: example.immutable !== undefined ? example.immutable : true, // Ensure immutable is set
+            isContextValid: example.isContextValid || ValidatedOptions.default,
+            validationError: example.validationError || '',
+            questionAndAnswer: {
+              ...example.questionAndAnswer,
+              immutable: example.questionAndAnswer.immutable !== undefined ? example.questionAndAnswer.immutable : true, // Ensure immutable is set
+              isQuestionValid: example.questionAndAnswer.isQuestionValid || ValidatedOptions.default,
+              questionValidationError: example.questionAndAnswer.questionValidationError || '',
+              isAnswerValid: example.questionAndAnswer.isAnswerValid || ValidatedOptions.default,
+              answerValidationError: example.questionAndAnswer.answerValidationError || ''
+            }
+          }))
+        }
+      : DefaultSkillFormData
+  );
   const [actionGroupAlertContent, setActionGroupAlertContent] = useState<ActionGroupAlertContent | undefined>();
   const [isYamlModalOpen, setIsYamlModalOpen] = useState<boolean>(false);
 
   const router = useRouter();
-
-  useEffect(() => {
-    if (skillEditFormData) {
-      setSkillFormData({
-        ...skillEditFormData.formData,
-        seedExamples: skillEditFormData.formData.seedExamples.map((example) => ({
-          ...example,
-          immutable: example.immutable !== undefined ? example.immutable : true, // Ensure immutable is set
-          isContextValid: example.isContextValid || ValidatedOptions.default,
-          validationError: example.validationError || '',
-          questionAndAnswer: {
-            ...example.questionAndAnswer,
-            immutable: example.questionAndAnswer.immutable !== undefined ? example.questionAndAnswer.immutable : true, // Ensure immutable is set
-            isQuestionValid: example.questionAndAnswer.isQuestionValid || ValidatedOptions.default,
-            questionValidationError: example.questionAndAnswer.questionValidationError || '',
-            isAnswerValid: example.questionAndAnswer.isAnswerValid || ValidatedOptions.default,
-            answerValidationError: example.questionAndAnswer.answerValidationError || ''
-          }
-        }))
-      });
-
-      devLog('Seed Examples Set from Edit Form Data:', skillEditFormData.formData.seedExamples);
-    }
-  }, [skillEditFormData]);
 
   const setFilePath = React.useCallback((filePath: string) => setSkillFormData((prev) => ({ ...prev, filePath })), []);
 

--- a/src/components/Contribute/Utils/seedExampleUtils.ts
+++ b/src/components/Contribute/Utils/seedExampleUtils.ts
@@ -130,7 +130,7 @@ export const handleKnowledgeSeedExamplesContextInputChange = (
   contextValue: string,
   validate = false
 ): KnowledgeSeedExample[] => {
-  const { msg, status } = validateContext(seedExamples[seedExampleIndex].context);
+  const { msg, status } = validateContext(contextValue);
   return seedExamples.map((seedExample: KnowledgeSeedExample, index: number) =>
     index === seedExampleIndex
       ? {


### PR DESCRIPTION
## Description
Fixes a bug where the context files are not shown in the select context modal for the first seed example.
Fixes a bug where the selected text does not fill the context input.
Addresses an issue where the wizard form data could be inadvertently reset.