### PR TITLE
Valid seed examples when uploading a skill yaml file

### DIFF
--- a/src/components/Contribute/Utils/uploadUtils.ts
+++ b/src/components/Contribute/Utils/uploadUtils.ts
@@ -45,16 +45,26 @@ export const addYamlUploadKnowledge = (knowledgeFormData: KnowledgeFormData, dat
 });
 
 const yamlSkillSeedExampleToFormSeedExample = (yamlSeedExamples: { question: string; context?: string | undefined; answer: string }[]) => {
-  return yamlSeedExamples.map((yamlSeedExample) => ({
-    immutable: true,
-    isExpanded: false,
-    context: yamlSeedExample.context ?? '',
-    questionAndAnswer: {
+  return yamlSeedExamples.map((yamlSeedExample) => {
+    const { context, question, answer } = yamlSeedExample;
+    const { msg: questionValidationError, status: isQuestionValid } = validateQuestion(question);
+    const { msg: answerValidationError, status: isAnswerValid } = validateQuestion(question);
+
+    return {
       immutable: true,
-      question: yamlSeedExample.question,
-      answer: yamlSeedExample.answer
-    }
-  })) as SkillSeedExample[];
+      isExpanded: false,
+      context,
+      questionAndAnswer: {
+        immutable: true,
+        question,
+        isQuestionValid,
+        questionValidationError,
+        answer,
+        isAnswerValid,
+        answerValidationError
+      }
+    };
+  }) as SkillSeedExample[];
 };
 
 export const addYamlUploadSkill = (skillFormData: SkillFormData, data: SkillYamlData): SkillFormData => ({


### PR DESCRIPTION
## Description
Fixes an issue where if you use the upload yaml to fill the skill form, seed example fails validation, even though question/answer pairs are filled.