### PR TITLE
Fix for granite chat submission

### DIFF
--- a/src/components/Chat/ChatBotComponent.tsx
+++ b/src/components/Chat/ChatBotComponent.tsx
@@ -153,7 +153,11 @@ const ChatBotComponent: React.FunctionComponent<ChatbotComponentProps> = ({
       };
 
       stopped.current = false;
-      await modelFetcher(model, input, setCurrentMessage, setController);
+      try {
+        await modelFetcher(model, input, setCurrentMessage, setController);
+      } catch (e) {
+        console.error(`Model fetch failed: `, e);
+      }
 
       setIsLoading(false);
       setFetching(false);

--- a/src/components/Chat/ChatBotContainer.tsx
+++ b/src/components/Chat/ChatBotContainer.tsx
@@ -77,10 +77,10 @@ const ChatBotContainer: React.FC = () => {
 
   const handleStopButton = () => {
     if (mainChatController) {
-      mainChatController.abort();
+      mainChatController.abort('user stopped');
     }
     if (altChatController) {
-      altChatController.abort();
+      altChatController.abort('user stopped');
     }
   };
 

--- a/src/components/Chat/modelService.ts
+++ b/src/components/Chat/modelService.ts
@@ -115,7 +115,7 @@ export const defaultModelFetcher = async (
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify({ input, systemRole }),
+      body: JSON.stringify({ question: input, systemRole }),
       signal: newController.signal
     }
   );


### PR DESCRIPTION
Fixes the submission to the server side chat fetch to correctly set the `question` field for the submission body.
Cleans up a couple console errors that occur if the user stops the submission.