### PR TITLE
Move convert and conver-http api out of native directory

### DIFF
--- a/src/app/api/convert/route.ts
+++ b/src/app/api/convert/route.ts
@@ -1,26 +1,28 @@
-// src/app/api/native/convert-http/route.ts
-'use server';
-
+// src/app/api/convert/route.ts
 import { NextResponse } from 'next/server';
 
-interface ConvertHttpRequestBody {
+`use server`;
+
+interface ConvertRequestBody {
   options?: {
-    from_formats?: string[];
-    to_formats?: string[];
-    image_export_mode?: string;
-    table_mode?: string;
-    abort_on_error?: boolean;
-    return_as_file?: boolean;
-    do_table_structure?: boolean;
+    output_markdown?: boolean;
     include_images?: boolean;
   };
-  http_sources: { url: string }[];
+  file_source: {
+    base64_string: string;
+    filename: string;
+  };
 }
 
-// convert a doc from a URL (provided via http_sources) to Markdown.
+// This route calls the external REST service to convert any doc => markdown
 export async function POST(request: Request) {
+  // 1. Parse JSON body from client
+  const body: ConvertRequestBody = await request.json();
+
+  // 2. Read the IL_FILE_CONVERSION_SERVICE from .env
   const baseUrl = process.env.IL_FILE_CONVERSION_SERVICE || 'http://doclingserve:5001';
 
+  // 3. Check the health of the conversion service before proceeding
   try {
     const healthRes = await fetch(`${baseUrl}/health`);
     if (!healthRes.ok) {
@@ -28,9 +30,10 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Conversion service is offline, only markdown files accepted.' }, { status: 503 });
     }
 
+    // Parse the health response body in case we need to verify its "status":"ok"
     const healthData = await healthRes.json();
     if (!healthData.status || healthData.status !== 'ok') {
-      console.error('Conversion service health check response not "ok":', healthData);
+      console.error('Doc->md conversion service health check response not "ok":', healthData);
       return NextResponse.json({ error: 'Conversion service is offline, only markdown files accepted.' }, { status: 503 });
     }
   } catch (error: unknown) {
@@ -38,12 +41,13 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Conversion service is offline, only markdown files accepted.' }, { status: 503 });
   }
 
+  // 4. Service is healthy, proceed with md conversion
   try {
-    const body: ConvertHttpRequestBody = await request.json();
-
     const res = await fetch(`${baseUrl}/v1alpha/convert/source`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json'
+      },
       body: JSON.stringify(body)
     });
 
@@ -52,17 +56,18 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: `Conversion service call failed. ${res.statusText}` }, { status: 500 });
     }
 
+    // 5. Wait for the docling service to return the user submitted file converted to markdown
     const data = await res.json();
 
-    // Return the markdown wrapped in JSON for the client to parse
+    // Return the markdown wrapped in JSON so the client side can parse it
     return NextResponse.json({ content: data }, { status: 200 });
   } catch (error: unknown) {
     if (error instanceof Error) {
-      console.error('Error during URL conversion route call:', error);
-      return NextResponse.json({ error: 'URL conversion failed.', message: error.message }, { status: 500 });
+      console.error('Error during doc->md conversion route call:', error);
+      return NextResponse.json({ error: 'md conversion failed.', message: error.message }, { status: 500 });
     } else {
       console.error('Unknown error during conversion route call:', error);
-      return NextResponse.json({ error: 'Conversion failed due to an unknown error.' }, { status: 500 });
+      return NextResponse.json({ error: 'conversion failed due to an unknown error.' }, { status: 500 });
     }
   }
 }

--- a/src/components/Contribute/Knowledge/FileConversionModal.tsx
+++ b/src/components/Contribute/Knowledge/FileConversionModal.tsx
@@ -54,7 +54,7 @@ export const FileConversionModal: React.FunctionComponent<Props> = ({ filesToCon
 
     // 2) Attempt conversion call
     try {
-      const res = await fetch('/api/native/convert', {
+      const res = await fetch('/api/convert', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/components/Contribute/Knowledge/UploadFromGitModal.tsx
+++ b/src/components/Contribute/Knowledge/UploadFromGitModal.tsx
@@ -68,7 +68,7 @@ export const UploadFromGitModal: React.FunctionComponent<Props> = ({ onAddFile, 
 
     try {
       // Call the API to get the document
-      const res = await fetch('/api/native/convert-http', {
+      const res = await fetch('/api/convert-http', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({


### PR DESCRIPTION
Both of these api's are not specific to only native mode. These api's are used across both the mode so it makes sense for them to be out of specific mode api's.