### PR TITLE
Change podman vllm filter to the ilab image

### DIFF
--- a/api-server/vllm-serve.go
+++ b/api-server/vllm-serve.go
@@ -29,7 +29,7 @@ func (srv *ILabServer) ListVllmContainers() ([]VllmContainer, error) {
 	format := "{{.ID}}|{{.Image}}|{{.Command}}|{{.CreatedAt}}|{{.Status}}|{{.Ports}}|{{.Names}}"
 
 	cmd := exec.Command("podman", "ps",
-		"--filter", "ancestor=vllm/vllm-openai:latest",
+		"--filter", "ancestor=registry.redhat.io/rhelai1/instructlab-nvidia-rhel9",
 		"--format", format,
 	)
 


### PR DESCRIPTION
- The vllm-status api call was filtering on the old `openai/vllm` image that has been migrated to the ilab image. Resolves any issues with `curl -X GET http://localhost:8080/vllm-containers` showing null when there are vllm instances.