### PR TITLE
Update word count overage to a warning rather than error

### DIFF
--- a/src/components/Contribute/Knowledge/KnowledgeSeedExamples/KnowledgeFileSelectModal.tsx
+++ b/src/components/Contribute/Knowledge/KnowledgeSeedExamples/KnowledgeFileSelectModal.tsx
@@ -21,6 +21,7 @@ import {
 import { KnowledgeFile } from '@/types';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { getWordCount } from '@/components/Contribute/Utils/contributionUtils';
+import { MAX_CONTEXT_WORDS } from '@/components/Contribute/Utils/seedExampleUtils';
 
 interface Props {
   knowledgeFile: KnowledgeFile;
@@ -110,7 +111,7 @@ const KnowledgeFileSelectModal: React.FC<Props> = ({ knowledgeFile, initialSelec
       <ModalHeader
         labelId="select-context-title"
         title="Select Context"
-        description="To create a context, highlight 500 words or less. Selecting a combination of simple and complex contexts you can help prepare your model to handle various needs."
+        description={`To create a context, highlight up to ${MAX_CONTEXT_WORDS} words (recommended). Selecting a combination of simple and complex contexts you can help prepare your model to handle various needs.`}
       />
       <ModalBody id="select-context-body" style={{ paddingTop: 0, marginTop: MdSpacer.var }}>
         <Content
@@ -130,14 +131,14 @@ const KnowledgeFileSelectModal: React.FC<Props> = ({ knowledgeFile, initialSelec
       </ModalBody>
       <HelperText style={{ paddingLeft: LgSpacer.var, paddingTop: XsSpacer.var }}>
         <HelperTextItem
-          icon={selectedWordCount > 500 ? <ExclamationCircleIcon /> : undefined}
-          variant={selectedWordCount > 500 ? ValidatedOptions.error : ValidatedOptions.default}
+          icon={selectedWordCount > MAX_CONTEXT_WORDS ? <ExclamationCircleIcon /> : undefined}
+          variant={selectedWordCount > MAX_CONTEXT_WORDS ? ValidatedOptions.warning : ValidatedOptions.default}
         >
-          {selectedWordCount} / 500 words
+          {`${selectedWordCount} / ${MAX_CONTEXT_WORDS} words${selectedWordCount > MAX_CONTEXT_WORDS ? ` (${selectedWordCount - MAX_CONTEXT_WORDS} over the recommended limit)` : ''}`}
         </HelperTextItem>
       </HelperText>
       <ModalFooter>
-        <Button variant="primary" onClick={() => handleUseSelectedText()} isDisabled={selectedWordCount === 0 || selectedWordCount > 500}>
+        <Button variant="primary" onClick={() => handleUseSelectedText()} isDisabled={selectedWordCount === 0}>
           Create context
         </Button>
         <Button variant="link" onClick={handleCloseModal}>

--- a/src/components/Contribute/Knowledge/KnowledgeSeedExamples/KnowledgeSeedExampleCard.tsx
+++ b/src/components/Contribute/Knowledge/KnowledgeSeedExamples/KnowledgeSeedExampleCard.tsx
@@ -395,8 +395,8 @@ const KnowledgeSeedExampleCard: React.FC<Props> = ({
                   {wordCount > MAX_CONTRIBUTION_Q_AND_A_WORDS ? (
                     <FormHelperText>
                       <HelperText className="q-and-a-field__text-help">
-                        <HelperTextItem icon={<ExclamationCircleIcon />} variant={ValidatedOptions.error}>
-                          {`${wordCount}/${MAX_CONTRIBUTION_Q_AND_A_WORDS} words total (${wordCount - MAX_CONTRIBUTION_Q_AND_A_WORDS} over limit)`}
+                        <HelperTextItem icon={<ExclamationCircleIcon />} variant={ValidatedOptions.warning}>
+                          {`${wordCount}/${MAX_CONTRIBUTION_Q_AND_A_WORDS} words total (${wordCount - MAX_CONTRIBUTION_Q_AND_A_WORDS} over the recommended limit)`}
                         </HelperTextItem>
                       </HelperText>
                     </FormHelperText>
@@ -418,14 +418,14 @@ const KnowledgeSeedExampleCard: React.FC<Props> = ({
               {areAllQuestionAnswerPairsValid ? (
                 wordCount > 0 ? (
                   <Alert
-                    title={`${wordCount}/${MAX_CONTRIBUTION_Q_AND_A_WORDS} words total${wordCount > MAX_CONTRIBUTION_Q_AND_A_WORDS ? `(${wordCount - MAX_CONTRIBUTION_Q_AND_A_WORDS} over limit)` : ''}`}
+                    title={`${wordCount}/${MAX_CONTRIBUTION_Q_AND_A_WORDS} words total${wordCount > MAX_CONTRIBUTION_Q_AND_A_WORDS ? ` (${wordCount - MAX_CONTRIBUTION_Q_AND_A_WORDS} over the recommended limit)` : ''}`}
                     isPlain
                     isInline
-                    variant={wordCount > MAX_CONTRIBUTION_Q_AND_A_WORDS ? 'danger' : 'info'}
+                    variant={wordCount > MAX_CONTRIBUTION_Q_AND_A_WORDS ? 'warning' : 'info'}
                   />
                 ) : (
                   <Alert
-                    title={`The combined word count of the three question-and-answer pairs in each seed example must not exceed ${MAX_CONTRIBUTION_Q_AND_A_WORDS} words.`}
+                    title={`The recommended combined word count of each seed example's question-and-answer pairs is ${MAX_CONTRIBUTION_Q_AND_A_WORDS} words or less.`}
                     isPlain
                     isInline
                     variant="info"

--- a/src/components/Contribute/Knowledge/KnowledgeSeedExamples/KnowledgeSeedExamples.scss
+++ b/src/components/Contribute/Knowledge/KnowledgeSeedExamples/KnowledgeSeedExamples.scss
@@ -9,6 +9,9 @@
       &.pf-m-info {
         background-color: var(--pf-t--color--blue--10);
       }
+      &.pf-m-warning {
+        background-color: #fdf7e7;
+      }
       &.pf-m-danger {
         background-color: #faeae8;
       }

--- a/src/components/Contribute/Knowledge/KnowledgeWizard/KnowledgeWizard.tsx
+++ b/src/components/Contribute/Knowledge/KnowledgeWizard/KnowledgeWizard.tsx
@@ -5,7 +5,7 @@ import './knowledge.css';
 import { useSession } from 'next-auth/react';
 import DocumentInformation from '@/components/Contribute/Knowledge/DocumentInformation/DocumentInformation';
 import KnowledgeSeedExamples from '@/components/Contribute/Knowledge/KnowledgeSeedExamples/KnowledgeSeedExamples';
-import { ContributionFormData, KnowledgeEditFormData, KnowledgeFormData, KnowledgeYamlData } from '@/types';
+import { ContributionFormData, KnowledgeEditFormData, KnowledgeFormData, KnowledgeSeedExample, KnowledgeYamlData } from '@/types';
 import { useRouter } from 'next/navigation';
 import { Button, ValidatedOptions } from '@patternfly/react-core';
 import { devLog } from '@/utils/devlog';
@@ -228,6 +228,12 @@ export const KnowledgeWizard: React.FunctionComponent<KnowledgeFormProps> = ({ k
             contributionFormData={knowledgeFormData}
             isGithubMode={isGithubMode}
             seedExamples={<KnowledgeSeedExamplesReviewSection seedExamples={knowledgeFormData.seedExamples} />}
+            onUpdateSeedExamples={(seedExamples) =>
+              setKnowledgeFormData((prev) => ({
+                ...prev,
+                seedExamples: seedExamples as KnowledgeSeedExample[]
+              }))
+            }
           />
         ),
         status: StepStatus.Default

--- a/src/components/Contribute/ReviewSubmission/ReviewSubmission.tsx
+++ b/src/components/Contribute/ReviewSubmission/ReviewSubmission.tsx
@@ -1,128 +1,148 @@
 // src/components/Contribute/ReviewSubmission/ReviewSubmission.tsx
 import React from 'react';
-import { ContributionFormData, KnowledgeFormData } from '@/types';
+import { ContributionFormData, KnowledgeFormData, KnowledgeSeedExample, SkillFormData, SkillSeedExample } from '@/types';
 import { Flex, DescriptionListGroup, DescriptionListTerm, DescriptionListDescription, FlexItem } from '@patternfly/react-core';
 import WizardPageHeader from '@/components/Common/WizardPageHeader';
 import ReviewSection from '@/components/Contribute/ReviewSubmission/ReviewSection';
+import { getValidatedKnowledgeSeedExamples, getValidatedSkillSeedExamples } from '@/components/Contribute/Utils/validationUtils';
 
 interface ReviewSubmissionProps {
   contributionFormData: ContributionFormData;
   seedExamples: React.ReactNode;
   isSkillContribution: boolean;
   isGithubMode: boolean;
+  onUpdateSeedExamples: (seedExamples: KnowledgeSeedExample[] | SkillSeedExample[]) => void;
 }
 
-export const ReviewSubmission: React.FC<ReviewSubmissionProps> = ({ contributionFormData, seedExamples, isSkillContribution, isGithubMode }) => (
-  <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
-    <FlexItem>
-      <WizardPageHeader title="Review" description={`Confirm the details of your ${isSkillContribution ? 'skill' : 'knowledge'} contribution.`} />
-    </FlexItem>
-    <FlexItem>
-      <Flex direction={{ default: 'column' }} gap={{ default: 'gapXl' }}>
-        {/* Author Information */}
-        <FlexItem>
-          <ReviewSection
-            title="Contributor details"
-            descriptionText="Information required for a Github Developer Certificate of Origin (DCO) sign-off."
-            descriptionItems={[
-              <DescriptionListGroup key="contributors">
-                <DescriptionListTerm>Contributors</DescriptionListTerm>
-                <DescriptionListDescription>
-                  <div>{contributionFormData.name}</div>
-                  <div>{contributionFormData.email}</div>
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-            ]}
-          />
-        </FlexItem>
+export const ReviewSubmission: React.FC<ReviewSubmissionProps> = ({
+  contributionFormData,
+  seedExamples,
+  isSkillContribution,
+  isGithubMode,
+  onUpdateSeedExamples
+}) => {
+  React.useEffect(() => {
+    if (!isSkillContribution) {
+      onUpdateSeedExamples(getValidatedKnowledgeSeedExamples(contributionFormData as KnowledgeFormData));
+      return;
+    }
+    onUpdateSeedExamples(getValidatedSkillSeedExamples(contributionFormData as SkillFormData));
+    // Don't update on form data changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSkillContribution]);
 
-        {/* Knowledge/Skill Information */}
-        <FlexItem>
-          <ReviewSection
-            title="Contribution information"
-            descriptionText="Brief summary of your contribution, and the directory path for your reference documents."
-            descriptionItems={[
-              <DescriptionListGroup key="submission-summary">
-                <DescriptionListTerm>Contribution summary</DescriptionListTerm>
-                <DescriptionListDescription>
-                  <div>{contributionFormData.submissionSummary}</div>
-                </DescriptionListDescription>
-              </DescriptionListGroup>,
-              <DescriptionListGroup key="file-path">
-                <DescriptionListTerm>Directory path</DescriptionListTerm>
-                <DescriptionListDescription>
-                  <div>{contributionFormData.filePath}</div>
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-            ]}
-          />
-        </FlexItem>
-
-        {/* Attribution Information */}
-        {isGithubMode ? (
+  return (
+    <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
+      <FlexItem>
+        <WizardPageHeader title="Review" description={`Confirm the details of your ${isSkillContribution ? 'skill' : 'knowledge'} contribution.`} />
+      </FlexItem>
+      <FlexItem>
+        <Flex direction={{ default: 'column' }} gap={{ default: 'gapXl' }}>
+          {/* Author Information */}
           <FlexItem>
             <ReviewSection
-              title="Source attribution"
+              title="Contributor details"
+              descriptionText="Information required for a Github Developer Certificate of Origin (DCO) sign-off."
               descriptionItems={[
-                <DescriptionListGroup key="title-work">
-                  <DescriptionListTerm>Title</DescriptionListTerm>
+                <DescriptionListGroup key="contributors">
+                  <DescriptionListTerm>Contributors</DescriptionListTerm>
                   <DescriptionListDescription>
-                    <div>{contributionFormData.titleWork}</div>
-                  </DescriptionListDescription>
-                </DescriptionListGroup>,
-                ...(!isSkillContribution
-                  ? [
-                      <DescriptionListGroup key="work-link">
-                        <DescriptionListTerm>Link to work</DescriptionListTerm>
-                        <DescriptionListDescription>
-                          <div>{(contributionFormData as KnowledgeFormData).linkWork}</div>
-                        </DescriptionListDescription>
-                      </DescriptionListGroup>
-                    ]
-                  : []),
-                ...(!isSkillContribution
-                  ? [
-                      <DescriptionListGroup key="revision">
-                        <DescriptionListTerm>Revision</DescriptionListTerm>
-                        <DescriptionListDescription>
-                          <div>{(contributionFormData as KnowledgeFormData).revision}</div>
-                        </DescriptionListDescription>
-                      </DescriptionListGroup>
-                    ]
-                  : []),
-                <DescriptionListGroup key="license">
-                  <DescriptionListTerm>License of the work</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <div>{contributionFormData.licenseWork}</div>
-                  </DescriptionListDescription>
-                </DescriptionListGroup>,
-                <DescriptionListGroup key="creators">
-                  <DescriptionListTerm>Authors</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <div>{contributionFormData.creators}</div>
+                    <div>{contributionFormData.name}</div>
+                    <div>{contributionFormData.email}</div>
                   </DescriptionListDescription>
                 </DescriptionListGroup>
               ]}
             />
           </FlexItem>
-        ) : null}
 
-        {/* Seed Examples */}
-        <FlexItem>
-          <ReviewSection
-            title="Seed data"
-            descriptionText="Data that will be used to start teaching your model."
-            descriptionItems={[
-              <DescriptionListGroup key="examples">
-                <DescriptionListTerm>Examples</DescriptionListTerm>
-                <DescriptionListDescription>{seedExamples}</DescriptionListDescription>
-              </DescriptionListGroup>
-            ]}
-          />
-        </FlexItem>
-      </Flex>
-    </FlexItem>
-  </Flex>
-);
+          {/* Knowledge/Skill Information */}
+          <FlexItem>
+            <ReviewSection
+              title="Contribution information"
+              descriptionText="Brief summary of your contribution, and the directory path for your reference documents."
+              descriptionItems={[
+                <DescriptionListGroup key="submission-summary">
+                  <DescriptionListTerm>Contribution summary</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <div>{contributionFormData.submissionSummary}</div>
+                  </DescriptionListDescription>
+                </DescriptionListGroup>,
+                <DescriptionListGroup key="file-path">
+                  <DescriptionListTerm>Directory path</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <div>{contributionFormData.filePath}</div>
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              ]}
+            />
+          </FlexItem>
+
+          {/* Attribution Information */}
+          {isGithubMode ? (
+            <FlexItem>
+              <ReviewSection
+                title="Source attribution"
+                descriptionItems={[
+                  <DescriptionListGroup key="title-work">
+                    <DescriptionListTerm>Title</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <div>{contributionFormData.titleWork}</div>
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>,
+                  ...(!isSkillContribution
+                    ? [
+                        <DescriptionListGroup key="work-link">
+                          <DescriptionListTerm>Link to work</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            <div>{(contributionFormData as KnowledgeFormData).linkWork}</div>
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                      ]
+                    : []),
+                  ...(!isSkillContribution
+                    ? [
+                        <DescriptionListGroup key="revision">
+                          <DescriptionListTerm>Revision</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            <div>{(contributionFormData as KnowledgeFormData).revision}</div>
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                      ]
+                    : []),
+                  <DescriptionListGroup key="license">
+                    <DescriptionListTerm>License of the work</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <div>{contributionFormData.licenseWork}</div>
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>,
+                  <DescriptionListGroup key="creators">
+                    <DescriptionListTerm>Authors</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <div>{contributionFormData.creators}</div>
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                ]}
+              />
+            </FlexItem>
+          ) : null}
+
+          {/* Seed Examples */}
+          <FlexItem>
+            <ReviewSection
+              title="Seed data"
+              descriptionText="Data that will be used to start teaching your model."
+              descriptionItems={[
+                <DescriptionListGroup key="examples">
+                  <DescriptionListTerm>Examples</DescriptionListTerm>
+                  <DescriptionListDescription>{seedExamples}</DescriptionListDescription>
+                </DescriptionListGroup>
+              ]}
+            />
+          </FlexItem>
+        </Flex>
+      </FlexItem>
+    </Flex>
+  );
+};
 
 export default ReviewSubmission;

--- a/src/components/Contribute/Skill/SkillWizard/SkillWizard.tsx
+++ b/src/components/Contribute/Skill/SkillWizard/SkillWizard.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import { ValidatedOptions, Button } from '@patternfly/react-core';
 import { devLog } from '@/utils/devlog';
 import { SkillSchemaVersion } from '@/types/const';
-import { ContributionFormData, SkillEditFormData, SkillFormData, SkillYamlData } from '@/types';
+import { ContributionFormData, SkillEditFormData, SkillFormData, SkillSeedExample, SkillYamlData } from '@/types';
 import { ActionGroupAlertContent } from '@/components/Contribute/types';
 import { isAttributionInformationValid, isSkillSeedExamplesValid, isDetailsValid } from '@/components/Contribute/Utils/validationUtils';
 import {
@@ -150,6 +150,7 @@ export const SkillWizard: React.FunctionComponent<Props> = ({ skillEditFormData,
             isSkillContribution
             isGithubMode={isGithubMode}
             seedExamples={<SkillSeedExamplesReviewSection seedExamples={skillFormData.seedExamples} />}
+            onUpdateSeedExamples={(seedExamples) => setSkillFormData((prev) => ({ ...prev, seedExamples: seedExamples as SkillSeedExample[] }))}
           />
         ),
         status: StepStatus.Default

--- a/src/components/Contribute/Utils/seedExampleUtils.ts
+++ b/src/components/Contribute/Utils/seedExampleUtils.ts
@@ -29,17 +29,11 @@ export const validateSkillAnswer = (answer: string) => {
 };
 
 export const validateContext = (context?: string) => {
-  // Split the context into words based on spaces
   const contextStr = context?.trim() ?? '';
   if (contextStr.length === 0) {
     return { msg: 'Context is required', status: ValidatedOptions.error };
   }
-  const tokens = contextStr.split(/\s+/);
-  if (tokens.length > 0 && tokens.length <= MAX_CONTEXT_WORDS) {
-    return { msg: 'Valid Input', status: ValidatedOptions.success };
-  }
-  const errorMsg = `Context must be less than ${MAX_CONTEXT_WORDS} words. Current word count: ` + tokens.length;
-  return { msg: errorMsg, status: ValidatedOptions.error };
+  return { msg: 'Valid Input', status: ValidatedOptions.success };
 };
 
 export const handleSkillSeedExamplesContextInputChange = (

--- a/src/components/Contribute/Utils/validationUtils.ts
+++ b/src/components/Contribute/Utils/validationUtils.ts
@@ -1,7 +1,5 @@
 import { ValidatedOptions } from '@patternfly/react-core';
 import { ContributionFormData, KnowledgeFormData, SkillFormData } from '@/types';
-import { getWordCount } from '@/components/Contribute/Utils/contributionUtils';
-import { MAX_CONTRIBUTION_Q_AND_A_WORDS } from '@/components/Contribute/Utils/seedExampleUtils';
 
 export const MAX_SUMMARY_CHARS = 256;
 
@@ -52,12 +50,9 @@ export const isKnowledgeSeedExamplesValid = (knowledgeFormData: KnowledgeFormDat
   }
 
   return knowledgeFormData.seedExamples.every((seedExample) => {
-    const wordCount = seedExample.questionAndAnswers.reduce<number>((acc, next) => acc + getWordCount(next.question) + getWordCount(next.answer), 0);
-
     return (
       seedExample.context.trim().length > 0 &&
       seedExample.isContextValid !== ValidatedOptions.error &&
-      wordCount <= MAX_CONTRIBUTION_Q_AND_A_WORDS &&
       seedExample.questionAndAnswers.every(
         (questionAndAnswerPair) =>
           questionAndAnswerPair.question.trim().length > 0 &&
@@ -68,6 +63,39 @@ export const isKnowledgeSeedExamplesValid = (knowledgeFormData: KnowledgeFormDat
     );
   });
 };
+
+export const getValidatedSkillSeedExamples = (formData: SkillFormData) =>
+  formData.seedExamples.map((seedExample) => {
+    const isQuestionValid = seedExample.questionAndAnswer.question.trim().length > 0;
+    const isAnswerValid = seedExample.questionAndAnswer.answer.trim().length > 0;
+    return {
+      ...seedExample,
+      questionAndAnswer: {
+        ...seedExample.questionAndAnswer,
+        isQuestionValid: isQuestionValid ? ValidatedOptions.default : ValidatedOptions.error,
+        questionValidationError: isQuestionValid ? undefined : 'Required',
+        isAnswerValid: isAnswerValid ? ValidatedOptions.default : ValidatedOptions.error,
+        answerValidationError: isAnswerValid ? undefined : 'Required'
+      }
+    };
+  });
+
+export const getValidatedKnowledgeSeedExamples = (formData: KnowledgeFormData) =>
+  formData.seedExamples.map((seedExample) => ({
+    ...seedExample,
+    questionAndAnswers: seedExample.questionAndAnswers.map((questionAndAnswer) => {
+      const isQuestionValid = questionAndAnswer.question.trim().length > 0;
+      const isAnswerValid = questionAndAnswer.answer.trim().length > 0;
+
+      return {
+        ...questionAndAnswer,
+        isQuestionValid: isQuestionValid ? ValidatedOptions.default : ValidatedOptions.error,
+        questionValidationError: isQuestionValid ? undefined : 'Required',
+        isAnswerValid: isAnswerValid ? ValidatedOptions.default : ValidatedOptions.error,
+        answerValidationError: isAnswerValid ? undefined : 'Required'
+      };
+    })
+  }));
 
 export const isAttributionInformationValid = (contributionFormData: ContributionFormData): boolean => {
   const { titleWork, licenseWork, creators } = contributionFormData;


### PR DESCRIPTION
### Description

Change error visuals/text to warnings for seed example word counts. Allow saving when over the recommended word count limits.
Update the seed example validations when reaching the review step so that errors are shown correctly when navigating back to the seed example step.

### Screen shots

![image](https://github.com/user-attachments/assets/db61e7de-f6d7-413d-983e-569dba5f5537)


![image](https://github.com/user-attachments/assets/a4d050f5-28ea-4a5f-b3ba-b6bdf25c606f)


![image](https://github.com/user-attachments/assets/a2e65029-7168-495c-ad3f-6c632ab9a161)


![image](https://github.com/user-attachments/assets/abac3210-82a2-4c78-8cb2-1e1e943f2d1f)


![image](https://github.com/user-attachments/assets/021744f5-847c-443b-acdd-cf498f07929d)


/cc @kaedward