### PR TITLE
Differentiate submission summary placeholder text for Skills and Knowledge contributions

### DIFF
--- a/src/components/Contribute/ContributionWizard/DetailsPage/DetailsPage.tsx
+++ b/src/components/Contribute/ContributionWizard/DetailsPage/DetailsPage.tsx
@@ -33,6 +33,7 @@ interface Props {
   setName: (val: string) => void;
   submissionSummary: string;
   setSubmissionSummary: (val: string) => void;
+  submissionSummaryPlaceholder: string;
   rootPath: string;
   filePath: string;
   setFilePath: (val: string) => void;
@@ -48,7 +49,8 @@ const DetailsPage: React.FC<Props> = ({
   setSubmissionSummary,
   rootPath,
   filePath,
-  setFilePath
+  setFilePath,
+  submissionSummaryPlaceholder
 }) => {
   const [editContributorOpen, setEditContributorOpen] = React.useState<boolean>();
   const [validSummary, setValidSummary] = React.useState<ValidatedOptions>(ValidatedOptions.default);
@@ -131,7 +133,7 @@ const DetailsPage: React.FC<Props> = ({
                   resizeOrientation="vertical"
                   type="text"
                   aria-label="submission_summary"
-                  placeholder="Example: Information about the Phoenix Constellation including the history, characteristics, and features of the stars in the constellation."
+                  placeholder={submissionSummaryPlaceholder}
                   value={submissionSummary}
                   validated={isSummaryInvalid ? ValidatedOptions.error : ValidatedOptions.default}
                   onChange={(_event, value) => setSubmissionSummary(value)}

--- a/src/components/Contribute/Knowledge/KnowledgeWizard/KnowledgeWizard.tsx
+++ b/src/components/Contribute/Knowledge/KnowledgeWizard/KnowledgeWizard.tsx
@@ -124,6 +124,7 @@ export const KnowledgeWizard: React.FunctionComponent<KnowledgeFormProps> = ({ k
                 submissionSummary
               }))
             }
+            submissionSummaryPlaceholder="Describe the main idea or information this example teaches (e.g., defining a scientific term, explaining a historical event)."
             rootPath="knowledge"
             filePath={knowledgeFormData.filePath}
             setFilePath={setFilePath}

--- a/src/components/Contribute/Skill/SkillWizard/SkillWizard.tsx
+++ b/src/components/Contribute/Skill/SkillWizard/SkillWizard.tsx
@@ -102,6 +102,7 @@ export const SkillWizard: React.FunctionComponent<Props> = ({ skillEditFormData 
                 submissionSummary
               }))
             }
+            submissionSummaryPlaceholder="Describe the skill this example helps the model learn (e.g., solving math problems, spotting grammar mistakes)"
             rootPath="skills"
             filePath={skillFormData.filePath}
             setFilePath={setFilePath}


### PR DESCRIPTION
## Quick summary

Relates to #787

In this PR we're updating the "Skill Contribution Summary" and "Knowledge Contribution Summary" placeholder texts to have different texts.

Previously, bo used the same text: `"Example: Information about the Phoenix Constellation including the history, characteristics, and features of the stars in the constellation."`

Now, the `ContributionWizard/DetailsPage/DetailsPage.tsx` component accepts a new prop: `submissionSummaryPlaceholder`, replacing the hardcoded text and enabling dynamic customization.

I used the following texts:

Knowledge: `"Describe the main idea or information this example teaches (e.g., defining a scientific term, explaining a historical event)."`

Skill: `"Describe the skill this example helps the model learn (e.g., solving math problems, spotting grammar mistakes)"`

☕ 

## Visual references

Knowledge:

![knowledge-contribution-summary-placeholder](https://github.com/user-attachments/assets/81b10d9e-c4dd-4a93-ac15-0016635d0c1b)

Skill:

![skills-contribution-summary-placeholder](https://github.com/user-attachments/assets/4c09fe37-e9a8-452e-83f4-33867b1d60f7)

