### PR TITLE
Add In-App Documentation

### DIFF
--- a/src/app/playground/chat/page.tsx
+++ b/src/app/playground/chat/page.tsx
@@ -2,46 +2,32 @@
 'use client';
 
 import React from 'react';
-import { useRouter } from 'next/navigation';
-import { Button, PageSection, Content } from '@patternfly/react-core/';
-import { t_global_spacer_sm as SmSpacerSize } from '@patternfly/react-tokens';
+import { PageSection, Content } from '@patternfly/react-core/';
 import { AppLayout } from '@/components/AppLayout';
+import ChatPageSidePanelHelp from '@/components/SidePanelContents/ChatPageSidePanelHelp';
+import PageDescriptionWithHelp from '@/components/Common/PageDescriptionWithHelp';
 import ModelsContextProvider from '../../../components/Chat/ModelsContext';
 import ChatBotContainer from '../../../components/Chat/ChatBotContainer';
 
 import './chatbotPage.css';
 
-const ChatPage: React.FC = () => {
-  const router = useRouter();
-
-  return (
-    <AppLayout className="chatBotPage">
-      <PageSection>
-        <Content component="h1">Chat with a model</Content>
-        <Content style={{ marginBottom: SmSpacerSize.var }}>
-          {`Before you start adding new skills and knowledge to your model, you can check its baseline
+const ChatPage: React.FC = () => (
+  <AppLayout className="chatBotPage">
+    <PageSection>
+      <Content component="h1">Chat with a model</Content>
+      <PageDescriptionWithHelp
+        description={`Before you start adding new skills and knowledge to your model, you can check its baseline
           performance by chatting with a language model that's hosted on your cloud. Choose a supported model
            from the model selector or configure your own custom endpoints to gain direct access
           to a specific model you've trained.`}
-        </Content>
-        <Button
-          component="a"
-          href="/playground/endpoints"
-          variant="link"
-          isInline
-          onClick={(e) => {
-            e.preventDefault();
-            router.push('/playground/endpoints');
-          }}
-        >
-          Learn more about managing custom model endpoints
-        </Button>
-      </PageSection>
-      <ModelsContextProvider>
-        <ChatBotContainer />
-      </ModelsContextProvider>
-    </AppLayout>
-  );
-};
+        helpText="Learn more about chatting with models"
+        sidePanelContent={<ChatPageSidePanelHelp />}
+      />
+    </PageSection>
+    <ModelsContextProvider>
+      <ChatBotContainer />
+    </ModelsContextProvider>
+  </AppLayout>
+);
 
 export default ChatPage;

--- a/src/app/playground/endpoints/page.tsx
+++ b/src/app/playground/endpoints/page.tsx
@@ -14,17 +14,18 @@ import {
   Flex,
   FlexItem,
   PageSection,
-  Title,
   Truncate,
   ClipboardCopy
 } from '@patternfly/react-core';
 import { BanIcon, CheckCircleIcon, EyeSlashIcon, EyeIcon, QuestionCircleIcon } from '@patternfly/react-icons';
-import { AppLayout } from '@/components/AppLayout';
 import { Endpoint, ModelEndpointStatus } from '@/types';
+import { fetchEndpointStatus } from '@/services/modelService';
+import { AppLayout } from '@/components/AppLayout';
+import CustomEndpointsSidePanelHelp from '@/components/SidePanelContents/CustomEndpointsSidePanelHelp';
 import EditEndpointModal from '@/app/playground/endpoints/EditEndpointModal';
 import DeleteEndpointModal from '@/app/playground/endpoints/DeleteEndpoinModal';
 import EndpointActions from '@/app/playground/endpoints/EndpointActions';
-import { fetchEndpointStatus } from '@/services/modelService';
+import PageDescriptionWithHelp from '@/components/Common/PageDescriptionWithHelp';
 
 const iconForStatus = (status: ModelEndpointStatus) => {
   switch (status) {
@@ -188,22 +189,22 @@ const EndpointsPage: React.FC = () => {
 
   return (
     <AppLayout>
-      <PageSection hasBodyWrapper={false}>
-        <Flex direction={{ default: 'column' }}>
+      <PageSection>
+        <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }} gap={{ default: 'gapMd' }}>
           <FlexItem>
-            <Title headingLevel="h1">Custom model endpoints</Title>
+            <Content component="h1">Custom model endpoints</Content>
           </FlexItem>
-          <FlexItem>
-            <Content component="p">Custom model endpoints enable you to interact with and test fine-tuned models using the chat interface.</Content>
-          </FlexItem>
-        </Flex>
-      </PageSection>
-      <PageSection hasBodyWrapper={false}>
-        <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
           <FlexItem>
             <Button onClick={handleAddEndpoint}>Add custom endpoint</Button>
           </FlexItem>
         </Flex>
+        <PageDescriptionWithHelp
+          description="Custom model endpoints enable you to interact with and test fine-tuned models using the chat interface."
+          helpText="Learn more about chatting with models"
+          sidePanelContent={<CustomEndpointsSidePanelHelp />}
+        />
+      </PageSection>
+      <PageSection hasBodyWrapper={false}>
         <DataList aria-label="Endpoints list">
           <DataListItem key="property-headers">
             <DataListItemRow wrapModifier="breakWord">

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -6,7 +6,14 @@ import { usePathname, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useSession } from 'next-auth/react';
 import {
+  AlertGroup,
+  Alert,
+  AlertVariant,
+  AlertActionCloseButton,
   Bullseye,
+  Drawer,
+  DrawerContent,
+  DrawerContentBody,
   Spinner,
   Masthead,
   MastheadMain,
@@ -24,20 +31,17 @@ import {
   PageSidebar,
   PageSidebarBody,
   SkipToContent,
-  Page,
-  AlertGroup,
-  Alert,
-  AlertVariant,
-  AlertActionCloseButton
+  Page
 } from '@patternfly/react-core';
 import { BarsIcon } from '@patternfly/react-icons';
+import { useFeatureFlags } from '@/context/FeatureFlagsContext';
+import { useAlerts } from '@/context/AlertContext';
+import { useSideDrawer } from '@/context/SideDrawerContext';
 import ThemePreference from '@/components/ThemePreference/ThemePreference';
 import HelpDropdown from './HelpDropdown/HelpDropdown';
 import UserMenu from './UserMenu/UserMenu';
 
 import '../styles/globals.scss';
-import { useFeatureFlags } from '@/context/FeatureFlagsContext';
-import { useAlerts } from '@/context/AlertContext';
 
 interface IAppLayout {
   children: React.ReactNode;
@@ -62,6 +66,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children, className })
     featureFlags: { playgroundFeaturesEnabled, experimentalFeaturesEnabled }
   } = useFeatureFlags();
   const { alerts, removeAlert } = useAlerts();
+  const sideDrawerContext = useSideDrawer();
 
   const router = useRouter();
   const pathname = usePathname();
@@ -183,28 +188,34 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children, className })
   const PageSkipToContent = <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>;
 
   return (
-    <Page
-      className={className}
-      mainContainerId={pageId}
-      masthead={Header}
-      isManagedSidebar
-      sidebar={Sidebar}
-      skipToContent={PageSkipToContent}
-      isContentFilled
-    >
-      {children}
-      <AlertGroup isToast isLiveRegion>
-        {alerts.map((alert) => (
-          <Alert
-            variant={alert.variant ? AlertVariant[alert.variant] : undefined}
-            title={alert.title}
-            timeout={true}
-            actionClose={<AlertActionCloseButton title={alert.title} onClose={() => removeAlert(alert.key)} />}
-            key={alert.key}
-          />
-        ))}
-      </AlertGroup>
-    </Page>
+    <Drawer isExpanded={!!sideDrawerContext.setSideDrawerContent} isInline>
+      <DrawerContent panelContent={sideDrawerContext.sideDrawerContent}>
+        <DrawerContentBody>
+          <Page
+            className={className}
+            mainContainerId={pageId}
+            masthead={Header}
+            isManagedSidebar
+            sidebar={Sidebar}
+            skipToContent={PageSkipToContent}
+            isContentFilled
+          >
+            {children}
+            <AlertGroup isToast isLiveRegion>
+              {alerts.map((alert) => (
+                <Alert
+                  variant={alert.variant ? AlertVariant[alert.variant] : undefined}
+                  title={alert.title}
+                  timeout={true}
+                  actionClose={<AlertActionCloseButton title={alert.title} onClose={() => removeAlert(alert.key)} />}
+                  key={alert.key}
+                />
+              ))}
+            </AlertGroup>
+          </Page>
+        </DrawerContentBody>
+      </DrawerContent>
+    </Drawer>
   );
 };
 

--- a/src/components/ClientProviders.tsx
+++ b/src/components/ClientProviders.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from '@/context/ThemeContext';
 import { EnvConfigProvider } from '@/context/EnvConfigContext';
 import { FeatureFlagsProvider } from '@/context/FeatureFlagsContext';
 import { AlertProvider } from '@/context/AlertContext';
+import { SideDrawerProvider } from '@/context/SideDrawerContext';
 
 interface ClientProviderProps {
   children: ReactNode;
@@ -18,7 +19,9 @@ const ClientProvider = ({ children }: ClientProviderProps) => {
       <EnvConfigProvider>
         <FeatureFlagsProvider>
           <ThemeProvider>
-            <AlertProvider>{children}</AlertProvider>
+            <SideDrawerProvider>
+              <AlertProvider>{children}</AlertProvider>
+            </SideDrawerProvider>
           </ThemeProvider>
         </FeatureFlagsProvider>
       </EnvConfigProvider>

--- a/src/components/Common/PageDescriptionWithHelp.tsx
+++ b/src/components/Common/PageDescriptionWithHelp.tsx
@@ -1,0 +1,36 @@
+// src/app/components/Common/PageDescriptionWithHelp.tsx
+'use client';
+
+import * as React from 'react';
+import { Button, Flex, FlexItem } from '@patternfly/react-core';
+import { useSideDrawer } from '@/context/SideDrawerContext';
+import XsOpenDrawerRightIcon from '@/components/Common/XsOpenDrawerRightIcon';
+
+interface Props {
+  description: React.ReactNode;
+  helpText: React.ReactNode;
+  sidePanelContent: React.ReactNode;
+}
+
+const PageDescriptionWithHelp: React.FC<Props> = ({ description, helpText, sidePanelContent }) => {
+  const sideDrawerContext = useSideDrawer();
+
+  return (
+    <Flex direction={{ default: 'column' }} gap={{ default: 'gapSm' }}>
+      <FlexItem>{description}</FlexItem>
+      <FlexItem>
+        <Button
+          variant="link"
+          isInline
+          icon={<XsOpenDrawerRightIcon />}
+          iconPosition="end"
+          onClick={() => sideDrawerContext.setSideDrawerContent(sidePanelContent)}
+        >
+          {helpText}
+        </Button>
+      </FlexItem>
+    </Flex>
+  );
+};
+
+export default PageDescriptionWithHelp;

--- a/src/components/Common/XsOpenDrawerRightIcon.tsx
+++ b/src/components/Common/XsOpenDrawerRightIcon.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import { OpenDrawerRightIcon } from '@patternfly/react-icons';
+import { t_global_font_size_xs as FontSizeXs } from '@patternfly/react-tokens';
+
+const XsExternalLinkAltIcon: React.FC = () => <OpenDrawerRightIcon style={{ width: FontSizeXs.var, height: FontSizeXs.var }} />;
+
+export default XsExternalLinkAltIcon;

--- a/src/components/Contribute/ContributePageHeader.tsx
+++ b/src/components/Contribute/ContributePageHeader.tsx
@@ -2,9 +2,10 @@
 'use client';
 
 import * as React from 'react';
-import { EditFormData, KnowledgeFormData, SkillFormData } from '@/types';
 import { useRouter } from 'next/navigation';
-import { PageSection, Flex, FlexItem, Title, Content, PageBreadcrumb, Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
+import { PageSection, Flex, FlexItem, Title, PageBreadcrumb, Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
+import { EditFormData, KnowledgeFormData, SkillFormData } from '@/types';
+import PageDescriptionWithHelp from '@/components/Common/PageDescriptionWithHelp';
 import {
   DraftContributionLabel,
   KnowledgeContributionLabel,
@@ -17,12 +18,22 @@ interface Props {
   isEdit?: boolean;
   isSkill?: boolean;
   description: React.ReactNode;
+  helpText: React.ReactNode;
+  sidePanelContent: React.ReactNode;
   actions: React.ReactNode;
 }
 
-const ContributePageHeader: React.FC<Props> = ({ editFormData, isEdit = false, isSkill = false, description, actions }) => {
+const ContributePageHeader: React.FC<Props> = ({
+  editFormData,
+  isEdit = false,
+  isSkill = false,
+  description,
+  helpText,
+  sidePanelContent,
+  actions
+}) => {
   const router = useRouter();
-  const contributionType = isSkill ? 'skills' : 'knowledge';
+  const contributionType = isSkill ? 'skill' : 'knowledge';
   const viewUrl = `/contribute/${isSkill ? 'skill' : 'knowledge'}/${editFormData?.formData.branchName}${editFormData?.isDraft ? '/isDraft' : ''}`;
   const contributionTitle = editFormData?.formData?.submissionSummary || `Draft ${contributionType} contribution`;
 
@@ -67,7 +78,7 @@ const ContributePageHeader: React.FC<Props> = ({ editFormData, isEdit = false, i
                     <Title headingLevel="h1" size="2xl">
                       {!editFormData
                         ? `Submit ${contributionType} contribution`
-                        : editFormData?.formData?.submissionSummary || `Draft ${isSkill ? 'skills' : 'knowledge'} contribution`}
+                        : editFormData?.formData?.submissionSummary || `Draft ${isSkill ? 'skill' : 'knowledge'} contribution`}
                     </Title>
                   </FlexItem>
                   <FlexItem>{isSkill ? <SkillContributionLabel /> : <KnowledgeContributionLabel />}</FlexItem>
@@ -84,7 +95,7 @@ const ContributePageHeader: React.FC<Props> = ({ editFormData, isEdit = false, i
                 </Flex>
               </FlexItem>
               <FlexItem>
-                <Content component="p">{description}</Content>
+                <PageDescriptionWithHelp description={description} helpText={helpText} sidePanelContent={sidePanelContent} />
               </FlexItem>
             </Flex>
           </FlexItem>

--- a/src/components/Contribute/ContributionLabels.tsx
+++ b/src/components/Contribute/ContributionLabels.tsx
@@ -16,7 +16,7 @@ const KnowledgeContributionLabel: React.FC<LabelProps> = ({ isCompact }) => (
 
 const SkillContributionLabel: React.FC<LabelProps> = ({ isCompact }) => (
   <Label className="skill-contribution-label" icon={<TaskIcon />} variant="outline" isCompact={isCompact}>
-    Skills
+    Skill
   </Label>
 );
 

--- a/src/components/Contribute/Knowledge/Edit/KnowledgeForm.tsx
+++ b/src/components/Contribute/Knowledge/Edit/KnowledgeForm.tsx
@@ -18,6 +18,7 @@ import {
 } from '@patternfly/react-core';
 import { KnowledgeEditFormData, KnowledgeFormData } from '@/types';
 import { ActionGroupAlertContent } from '@/components/Contribute/types';
+import KnowledgeContributionSidePanelHelp from '@/components/SidePanelContents/KnowledgeContributionSidePanelHelp';
 import ContributePageHeader from '@/components/Contribute/ContributePageHeader';
 import ContributeAlertGroup from '@/components/Contribute/ContributeAlertGroup';
 import { storeDraftData, deleteDraftData, doSaveDraft, isDraftDataExist } from '@/components/Contribute/Utils/autoSaveUtils';
@@ -37,6 +38,7 @@ export interface KnowledgeFormProps {
 
 export const KnowledgeForm: React.FunctionComponent<KnowledgeFormProps> = ({ knowledgeEditFormData }) => {
   const router = useRouter();
+
   const { data: session } = useSession();
   const [knowledgeFormData, setKnowledgeFormData] = React.useState<KnowledgeFormData>(
     knowledgeEditFormData?.formData
@@ -133,14 +135,16 @@ export const KnowledgeForm: React.FunctionComponent<KnowledgeFormProps> = ({ kno
         <ContributePageHeader
           isEdit
           editFormData={knowledgeEditFormData}
-          description="Knowledge contributions improve a model’s ability to answer questions accurately. They consist of questions and answers, and
-                  documents which back up that data."
+          description="Knowledge contributions improve a model’s ability to answer questions accurately. They consist of questions and answers, and documents
+                which back up that data. To autofill this form from a document, upload a YAML file."
+          sidePanelContent={<KnowledgeContributionSidePanelHelp />}
+          helpText="Learn more about knowledge contributions"
           actions={
             <KnowledgeFormActions
               contributionTitle={knowledgeEditFormData?.formData.submissionSummary ?? 'New contribution'}
               knowledgeFormData={knowledgeFormData}
               isDraft={knowledgeEditFormData?.isDraft}
-              isSubmitted={knowledgeEditFormData?.isDraft}
+              isSubmitted={knowledgeEditFormData?.isSubmitted}
               setActionGroupAlertContent={setActionGroupAlertContent}
               setKnowledgeFormData={setKnowledgeFormData}
             />

--- a/src/components/Contribute/Knowledge/KnowledgeFormActions.tsx
+++ b/src/components/Contribute/Knowledge/KnowledgeFormActions.tsx
@@ -287,15 +287,15 @@ export const KnowledgeFormActions: React.FunctionComponent<Props> = ({
       ) : null}
       {yamlOverwriteData ? (
         <Modal variant={ModalVariant.small} isOpen onClose={() => setYamlOverwriteData(undefined)} aria-labelledby="overwrite-confirm-title">
-          <ModalHeader titleIconVariant="warning" title="Uploading a new YAML file will clear existing data" labelId="overwrite-confirm-title" />
+          <ModalHeader titleIconVariant="warning" title="Overwrite unsaved changes?" labelId="overwrite-confirm-title" />
           <ModalBody>
             <>
-              Uploading a new YAML file will clear the current data for <strong>{contributionTitle}</strong>. Are you sure you want to continue?
+              Uploading a YAML file will overwrite all unsaved changes in the <strong>{contributionTitle}</strong> knowledge contribution.
             </>
           </ModalBody>
           <ModalFooter>
             <Button variant={ButtonVariant.primary} onClick={doYamlOverwrite}>
-              Continue
+              Overwrite unsaved changes
             </Button>
             <Button key="close" variant="link" onClick={doYamlOverwrite}>
               Cancel

--- a/src/components/Contribute/Knowledge/KnowledgeSeedExamples/KnowledgeSeedExampleCard.tsx
+++ b/src/components/Contribute/Knowledge/KnowledgeSeedExamples/KnowledgeSeedExampleCard.tsx
@@ -202,7 +202,7 @@ const KnowledgeSeedExampleCard: React.FC<Props> = ({
   };
 
   const clearSeedExample = () => {
-    onUpdateSeedExample(createEmptyKnowledgeSeedExample());
+    onUpdateSeedExample(createEmptyKnowledgeSeedExample(seedExample.immutable));
     setShowClearConfirmation(false);
   };
 
@@ -278,7 +278,11 @@ const KnowledgeSeedExampleCard: React.FC<Props> = ({
             <DropdownItem className="destructive-action-item" isDisabled={isEmpty} onClick={onClear}>
               Clear seed example
             </DropdownItem>
-            {!seedExample.immutable ? <DropdownItem onClick={onDelete}>Remove seed example</DropdownItem> : null}
+            {!seedExample.immutable ? (
+              <DropdownItem className="destructive-action-item" onClick={onDelete}>
+                Remove seed example
+              </DropdownItem>
+            ) : null}
           </DropdownList>
         </Dropdown>
       ) : null}
@@ -440,20 +444,16 @@ const KnowledgeSeedExampleCard: React.FC<Props> = ({
               onClose={() => (showClearConfirmation ? setShowClearConfirmation(false) : setShowDeleteConfirmation(false))}
             >
               <ModalHeader
-                title={
-                  <span>
-                    {showClearConfirmation ? 'Clear' : 'Remove'} <strong>{getKnowledgeSeedExampleTitle(seedExample, seedExampleIndex)}</strong>?
-                  </span>
-                }
+                title={<span>{showClearConfirmation ? 'Clear' : 'Remove'} context and Q and A pairs?</span>}
                 labelId="clear-warning-title"
-                titleIconVariant={showClearConfirmation ? 'warning' : 'danger'}
+                titleIconVariant="warning"
               />
-              <ModalBody id="clear-warning-message">The context selection and it’s 3 associated question-and-answer pairs will be lost.</ModalBody>
+              <ModalBody id="clear-warning-message">
+                The <strong>{getKnowledgeSeedExampleTitle(seedExample, seedExampleIndex)}</strong> context and its three associated
+                question-and-answer pairs will be deleted.
+              </ModalBody>
               <ModalFooter>
-                <Button
-                  variant={showClearConfirmation ? 'primary' : 'danger'}
-                  onClick={() => (showClearConfirmation ? clearSeedExample() : onDeleteSeedExample())}
-                >
+                <Button variant="primary" onClick={() => (showClearConfirmation ? clearSeedExample() : onDeleteSeedExample())}>
                   {showClearConfirmation ? 'Clear' : 'Remove'}
                 </Button>
                 <Button

--- a/src/components/Contribute/Knowledge/View/ViewKnowledge.tsx
+++ b/src/components/Contribute/Knowledge/View/ViewKnowledge.tsx
@@ -12,6 +12,7 @@ import {
   DescriptionListTerm,
   DescriptionListDescription
 } from '@patternfly/react-core';
+import KnowledgeContributionSidePanelHelp from '@/components/SidePanelContents/KnowledgeContributionSidePanelHelp';
 import ViewContributionSection from '@/components/Common/ViewContributionSection';
 import { ActionGroupAlertContent } from '@/components/Contribute/types';
 import ContributePageHeader from '@/components/Contribute/ContributePageHeader';
@@ -34,8 +35,10 @@ const ViewKnowledge: React.FC<ViewKnowledgeProps> = ({ knowledgeEditFormData }) 
     <PageGroup isFilled style={{ overflowY: 'hidden', flex: 1 }}>
       <ContributePageHeader
         editFormData={knowledgeEditFormData}
-        description="Knowledge contributions improve a model’s ability to answer questions accurately. They consist of questions and answers, and
-                  documents which back up that data."
+        description="Knowledge contributions improve a model’s ability to answer questions accurately. They consist of questions and answers, and documents
+              which back up that data."
+        sidePanelContent={<KnowledgeContributionSidePanelHelp />}
+        helpText="Learn more about knowledge contributions"
         actions={
           <KnowledgeFormActions
             contributionTitle={knowledgeEditFormData.formData.submissionSummary}

--- a/src/components/Contribute/Skill/Edit/EditSkill.tsx
+++ b/src/components/Contribute/Skill/Edit/EditSkill.tsx
@@ -30,7 +30,7 @@ const EditSkill: React.FC<EditSkillClientComponentProps> = ({ branchName, isDraf
     }
 
     const fetchBranchChanges = async () => {
-      setLoadingMsg('Fetching skills data from branch: ' + branchName);
+      setLoadingMsg('Fetching skill data from branch: ' + branchName);
       const { editFormData, error } = await fetchSkillBranchChanges(session, branchName);
       if (error) {
         setLoadingMsg(error);

--- a/src/components/Contribute/Skill/Edit/SkillForm.tsx
+++ b/src/components/Contribute/Skill/Edit/SkillForm.tsx
@@ -16,6 +16,7 @@ import {
   PageGroup
 } from '@patternfly/react-core';
 import { SkillEditFormData, SkillFormData } from '@/types';
+import SkillContributionSidePanelHelp from '@/components/SidePanelContents/SkillContributionSidePanelHelp';
 import { ActionGroupAlertContent } from '@/components/Contribute/types';
 import ContributeAlertGroup from '@/components/Contribute/ContributeAlertGroup';
 import ContributePageHeader from '@/components/Contribute/ContributePageHeader';
@@ -110,13 +111,16 @@ export const SkillForm: React.FunctionComponent<Props> = ({ skillEditFormData })
           editFormData={skillEditFormData}
           isEdit
           isSkill
-          description="Skill contributions improve a model’s ability to perform tasks. They consist of seed data which provide instructions for completing a task. To autofill this form from a document, upload a YAML file."
+          description="Skill contributions improve a model’s ability to perform tasks. They consist of seed data which provide instructions for completing a
+                  task. To autofill this form from a document, upload a YAML file."
+          helpText="Learn more about skill contributions"
+          sidePanelContent={<SkillContributionSidePanelHelp />}
           actions={
             <SkillFormActions
               contributionTitle={skillEditFormData?.formData.submissionSummary ?? 'New contribution'}
               skillFormData={skillFormData}
               isDraft={skillEditFormData?.isDraft}
-              isSubmitted={skillEditFormData?.isDraft}
+              isSubmitted={skillEditFormData?.isSubmitted}
               setActionGroupAlertContent={setActionGroupAlertContent}
               setSkillFormData={setSkillFormData}
             />

--- a/src/components/Contribute/Skill/SkillFormActions.tsx
+++ b/src/components/Contribute/Skill/SkillFormActions.tsx
@@ -144,7 +144,7 @@ export const SkillFormActions: React.FunctionComponent<Props> = ({
   const doYamlOverwrite = () => {
     if (yamlOverwriteData && setSkillFormData) {
       setSkillFormData(addYamlUploadSkill(skillFormData, yamlOverwriteData));
-      addAlert('Your skills form has been populated based on the uploaded YAML file.', 'success');
+      addAlert('Your skill form has been populated based on the uploaded YAML file.', 'success');
       setYamlOverwriteData(undefined);
     }
   };
@@ -162,7 +162,7 @@ export const SkillFormActions: React.FunctionComponent<Props> = ({
     }
 
     setSkillFormData(addYamlUploadSkill(skillFormData, data));
-    addAlert('Your skills form has been populated based on the uploaded YAML file.', 'success');
+    addAlert('Your skill form has been populated based on the uploaded YAML file.', 'success');
   };
 
   const autoFillForm = (): void => {
@@ -279,15 +279,15 @@ export const SkillFormActions: React.FunctionComponent<Props> = ({
       ) : null}
       {yamlOverwriteData ? (
         <Modal variant={ModalVariant.small} isOpen onClose={() => setYamlOverwriteData(undefined)} aria-labelledby="overwrite-confirm-title">
-          <ModalHeader titleIconVariant="warning" title="Uploading a new YAML file will clear existing data" labelId="overwrite-confirm-title" />
+          <ModalHeader titleIconVariant="warning" title="Overwrite unsaved changes?" labelId="overwrite-confirm-title" />
           <ModalBody>
             <>
-              Uploading a new YAML file will clear the current data for <strong>{contributionTitle}</strong>. Are you sure you want to continue?
+              Uploading a YAML file will overwrite all unsaved changes in the <strong>{contributionTitle}</strong> skill contribution.
             </>
           </ModalBody>
           <ModalFooter>
             <Button variant={ButtonVariant.primary} onClick={doYamlOverwrite}>
-              Continue
+              Overwrite unsaved changes
             </Button>
             <Button key="close" variant="link" onClick={doYamlOverwrite}>
               Cancel

--- a/src/components/Contribute/Skill/View/ViewSkill.tsx
+++ b/src/components/Contribute/Skill/View/ViewSkill.tsx
@@ -12,6 +12,7 @@ import {
   DescriptionListTerm,
   DescriptionListDescription
 } from '@patternfly/react-core';
+import SkillContributionSidePanelHelp from '@/components/SidePanelContents/SkillContributionSidePanelHelp';
 import ViewContributionSection from '@/components/Common/ViewContributionSection';
 import { ActionGroupAlertContent } from '@/components/Contribute/types';
 import ContributeAlertGroup from '@/components/Contribute/ContributeAlertGroup';
@@ -31,13 +32,16 @@ const ViewSkill: React.FC<ViewSkillProps> = ({ skillEditFormData }) => {
       <ContributePageHeader
         editFormData={skillEditFormData}
         isSkill
-        description="Skill contributions improve a model’s ability to perform tasks. They consist of seed data which provide instructions for completing a task."
+        description="Skill contributions improve a model’s ability to perform tasks. They consist of seed data which provide instructions for completing a
+              task."
+        sidePanelContent={<SkillContributionSidePanelHelp />}
+        helpText="Learn more about skill contributions"
         actions={
           <SkillFormActions
             contributionTitle={skillEditFormData.formData.submissionSummary}
             skillFormData={skillEditFormData.formData}
             isDraft={skillEditFormData?.isDraft}
-            isSubmitted={skillEditFormData?.isDraft}
+            isSubmitted={skillEditFormData?.isSubmitted}
             setActionGroupAlertContent={setActionGroupAlertContent}
           />
         }

--- a/src/components/Contribute/Skill/View/ViewSkillPage.tsx
+++ b/src/components/Contribute/Skill/View/ViewSkillPage.tsx
@@ -49,7 +49,7 @@ const ViewSkillPage: React.FC<ViewKnowledgeClientComponentProps> = ({ branchName
 
   if (isLoading || !skillEditFormData?.formData) {
     return (
-      <Modal variant={ModalVariant.small} title="Loading Skills Data" isOpen={isLoading} onClose={() => handleOnClose()}>
+      <Modal variant={ModalVariant.small} title="Loading skill data" isOpen={isLoading} onClose={() => handleOnClose()}>
         <ModalBody>
           <div>{loadingMsg}</div>
         </ModalBody>

--- a/src/components/Contribute/Utils/seedExampleUtils.ts
+++ b/src/components/Contribute/Utils/seedExampleUtils.ts
@@ -196,8 +196,8 @@ export const createDefaultSkillSeedExamples = (): SkillSeedExample[] => [
   createEmptySkillSeedExample()
 ];
 
-export const createEmptyKnowledgeSeedExample = (): KnowledgeSeedExample => ({
-  immutable: true,
+export const createEmptyKnowledgeSeedExample = (immutable = true): KnowledgeSeedExample => ({
+  immutable,
   isExpanded: false,
   context: '',
   isContextValid: ValidatedOptions.default,

--- a/src/components/Contribute/Utils/uploadUtils.ts
+++ b/src/components/Contribute/Utils/uploadUtils.ts
@@ -34,6 +34,7 @@ export const addYamlUploadKnowledge = (knowledgeFormData: KnowledgeFormData, dat
   knowledgeDocumentRepositoryUrl: data.document.repo ?? '',
   knowledgeDocumentCommit: data.document.commit ?? '',
   documentName: data.document.patterns.join(', ') ?? '',
+  filePath: data.domain,
   seedExamples: yamlKnowledgeSeedExampleToFormSeedExample(data.seed_examples)
 });
 

--- a/src/components/Contribute/YamlFileUpload.tsx
+++ b/src/components/Contribute/YamlFileUpload.tsx
@@ -56,12 +56,12 @@ const YamlFileUpload: React.FC<YamlFileUploadProps> = ({
         } else {
           const yamlFileSchemaIssueAlertContent: ActionGroupAlertContent = {
             title: 'YAML file upload error!',
-            message: `This yaml file does not match the Skills or Knowledge schema.`,
+            message: `This yaml file does not match the Skill or Knowledge schema.`,
             success: false,
             timeout: false
           };
           setActionGroupAlertContent(yamlFileSchemaIssueAlertContent);
-          console.error('This yaml file does not match the Skills or Knowledge schema');
+          console.error('This yaml file does not match the Skill or Knowledge schema');
         }
       } catch (error) {
         const yamlFileParsingIssueAlertContent: ActionGroupAlertContent = {

--- a/src/components/Dashboard/Dashboard.scss
+++ b/src/components/Dashboard/Dashboard.scss
@@ -28,8 +28,3 @@
     }
   }
 }
-.destructive-action-item {
-  .pf-v6-c-menu__item-text {
-    color: var(--pf-t--global--color--status--danger--100);
-  }
-}

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -5,7 +5,6 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import {
   PageSection,
   Title,
-  Content,
   Button,
   Spinner,
   EmptyState,
@@ -25,8 +24,8 @@ import { ContributionInfo } from '@/types';
 import { useFeatureFlags } from '@/context/FeatureFlagsContext';
 import { useEnvConfig } from '@/context/EnvConfigContext';
 import Table from '@/components/Table/Table';
+import ContributionsSidePanelHelp from '@/components/SidePanelContents/ContributionsSidePanelHelp';
 import CardView from '@/components/CardView/CardView';
-import XsExternalLinkAltIcon from '@/components/Common/XsExternalLinkAltIcon';
 import ClearDraftDataButton from '@/components/Contribute/ClearDraftDataButton';
 import {
   ContributionColumns,
@@ -41,6 +40,7 @@ import ContributionTableRow from '@/components/Dashboard/ContributionTableRow';
 import ContributionCard from '@/components/Dashboard/ContributionCard';
 
 import './Dashboard.scss';
+import PageDescriptionWithHelp from '@/components/Common/PageDescriptionWithHelp';
 
 const InstructLabLogo: React.FC = () => <Image src="/InstructLab-LogoFile-RGB-FullColor.svg" alt="InstructLab Logo" width={256} height={256} />;
 
@@ -49,8 +49,6 @@ interface Props {
   isLoading: boolean;
   triggerUpdateContributions: () => void;
 }
-
-const helpLinkUrl = `https://docs.instructlab.ai/user-interface/ui_overview`;
 
 const Dashboard: React.FC<Props> = ({ contributions, isLoading, triggerUpdateContributions }) => {
   const router = useRouter();
@@ -87,7 +85,7 @@ const Dashboard: React.FC<Props> = ({ contributions, isLoading, triggerUpdateCon
         params.set(name2, value2);
       }
 
-      router.push(pathname + '?' + params.toString());
+      router.replace(pathname + '?' + params.toString());
     },
     [pathname, router, searchParams]
   );
@@ -172,7 +170,7 @@ const Dashboard: React.FC<Props> = ({ contributions, isLoading, triggerUpdateCon
                     >
                       <DropdownList>
                         <DropdownItem onClick={() => router.push('/contribute/knowledge/')}>Contribute knowledge</DropdownItem>
-                        <DropdownItem onClick={() => router.push('/contribute/skill/')}>Contribute skills</DropdownItem>
+                        <DropdownItem onClick={() => router.push('/contribute/skill/')}>Contribute skill</DropdownItem>
                       </DropdownList>
                     </Dropdown>
                   ) : (
@@ -185,21 +183,11 @@ const Dashboard: React.FC<Props> = ({ contributions, isLoading, triggerUpdateCon
               </Flex>
             </FlexItem>
             <FlexItem>
-              <Content component="p">
-                View and manage your contributions. By contributing your own data, you can help train and refine your language models.
-              </Content>
-              <Button
-                variant="link"
-                isInline
-                component="a"
-                href={helpLinkUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                icon={<XsExternalLinkAltIcon />}
-                iconPosition="end"
-              >
-                {`Learn more about ${skillFeaturesEnabled ? 'knowledge and skills' : 'knowledge'} contributions`}
-              </Button>
+              <PageDescriptionWithHelp
+                description="View and manage your contributions. By contributing your own data, you can help train and refine your language models."
+                helpText="Learn more about contributions"
+                sidePanelContent={<ContributionsSidePanelHelp />}
+              />
             </FlexItem>
           </Flex>
         </FlexItem>

--- a/src/components/Dashboard/DashboardPage.tsx
+++ b/src/components/Dashboard/DashboardPage.tsx
@@ -92,21 +92,33 @@ const DashboardPage: React.FunctionComponent = () => {
 
   // Fetch branches from the API route
   React.useEffect(() => {
+    let canceled = false;
     let refreshIntervalId: NodeJS.Timeout;
 
     cloneTaxonomyRepo().then((success) => {
+      if (canceled) {
+        return;
+      }
       if (success) {
         fetchBranches().then(() => {
+          if (canceled) {
+            return;
+          }
           setIsLoading(false);
+          refreshIntervalId = setInterval(() => {
+            fetchBranches();
+          }, 60000);
         });
-        refreshIntervalId = setInterval(fetchBranches, 60000);
       } else {
         addAlert('Failed to fetch branches.', 'danger');
         setIsLoading(false);
       }
     });
 
-    return () => clearInterval(refreshIntervalId);
+    return () => {
+      canceled = true;
+      clearInterval(refreshIntervalId);
+    };
   }, [addAlert, fetchBranches]);
 
   React.useEffect(() => {

--- a/src/components/Documents/Documents.tsx
+++ b/src/components/Documents/Documents.tsx
@@ -1,13 +1,12 @@
 // src/components/Documents/Documents.tsx
 import * as React from 'react';
-import { PageSection, Title, Content, Button, Flex, FlexItem } from '@patternfly/react-core';
+import { PageSection, Title, Flex, FlexItem } from '@patternfly/react-core';
 import { KnowledgeFile } from '@/types';
 import { useAlerts } from '@/context/AlertContext';
-import XsExternalLinkAltIcon from '@/components/Common/XsExternalLinkAltIcon';
+import DocumentsSidePanelHelp from '@/components/SidePanelContents/DocumentsSidePanelHelp';
 import DocumentUploadArea from '@/components/Documents/DocumentUploadArea';
 import MyDocuments from '@/components/Documents/MyDocuments';
-
-const helpLinkUrl = `https://docs.instructlab.ai/user-interface/ui_overview`;
+import PageDescriptionWithHelp from '@/components/Common/PageDescriptionWithHelp';
 
 const Documents: React.FC = () => {
   const { addAlert } = useAlerts();
@@ -103,22 +102,12 @@ const Documents: React.FC = () => {
             </Flex>
           </FlexItem>
           <FlexItem>
-            <Content component="p">
-              Resources such as, textbooks, technical manuals, encyclopedias, journals, or websites, are used as the knowledge source for training
-              your model.
-            </Content>
-            <Button
-              variant="link"
-              isInline
-              component="a"
-              href={helpLinkUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              icon={<XsExternalLinkAltIcon />}
-              iconPosition="end"
-            >
-              Learn about best practices related to documents.
-            </Button>
+            <PageDescriptionWithHelp
+              description="Resources such as, textbooks, technical manuals, encyclopedias, journals, or websites, are used as the knowledge source for training
+              your model."
+              helpText="Learn how to add documents to knowledge contributions"
+              sidePanelContent={<DocumentsSidePanelHelp />}
+            />
           </FlexItem>
           <FlexItem flex={{ default: 'flex_1' }} style={{ overflowY: 'hidden' }}>
             <DocumentUploadArea existingFiles={documents} onUploaded={addDocuments} />

--- a/src/components/Documents/MyDocuments.tsx
+++ b/src/components/Documents/MyDocuments.tsx
@@ -58,7 +58,7 @@ const Documents: React.FC<Props> = ({ isLoading, documents, removeDocument }) =>
         params.set(name2, value2);
       }
 
-      router.push(pathname + '?' + params.toString());
+      router.replace(pathname + '?' + params.toString());
     },
     [pathname, router, searchParams]
   );

--- a/src/components/SidePanelContents/ChatPageSidePanelHelp.tsx
+++ b/src/components/SidePanelContents/ChatPageSidePanelHelp.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { Content } from '@patternfly/react-core';
+import SidePanelHelp from '@/components/SidePanelContents/SidePanelHelp';
+import { CustomEndpointsBody, CustomEndpointsDescription, CustomEndpointsTitle } from '@/components/SidePanelContents/CustomEndpointsSidePanelHelp';
+
+const ChatPageSidePanelHelp: React.FC = () => (
+  <SidePanelHelp
+    header="Chat with a model"
+    description={
+      <>
+        Use <strong>Chat with a model</strong> to test the performance of 1 or 2 models at a time. You can select a supported model to chat with, or
+        select one of your own models if it has a custom model endpoint configured.
+      </>
+    }
+    body={
+      <div>
+        <strong>Comparing model responses</strong>
+        <Content component="p">
+          To change how many models you are chatting with at a time, click the <strong>Compare</strong> toggle. Toggling on the{' '}
+          <strong>Compare</strong> feature enables you to send messages to 2 models or versions at once. This feature can be used to inspect the
+          models’ outputs and identify differences in style or accuracy.
+        </Content>
+        <strong>{CustomEndpointsTitle}</strong>
+        <Content component="p">
+          <CustomEndpointsDescription />
+        </Content>
+        <CustomEndpointsBody />
+      </div>
+    }
+  />
+);
+
+export default ChatPageSidePanelHelp;

--- a/src/components/SidePanelContents/ContributionsSidePanelHelp.tsx
+++ b/src/components/SidePanelContents/ContributionsSidePanelHelp.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import { useRouter } from 'next/navigation';
+import { Button, Content } from '@patternfly/react-core';
+import { useFeatureFlags } from '@/context/FeatureFlagsContext';
+import SidePanelHelp from '@/components/SidePanelContents/SidePanelHelp';
+
+interface Props {
+  knowledgeOnly?: boolean;
+}
+
+const ContributionsSidePanelHelp: React.FC<Props> = ({ knowledgeOnly }) => {
+  const router = useRouter();
+  const {
+    featureFlags: { skillFeaturesEnabled }
+  } = useFeatureFlags();
+  const showSkillsInfo = !knowledgeOnly && skillFeaturesEnabled;
+
+  return (
+    <SidePanelHelp
+      header="About contributions"
+      description={`Contributions enable you to teach your model new information.${showSkillsInfo ? ' There are two types of contributions: knowledge and skills.' : ''}`}
+      body={
+        <div>
+          <strong>Knowledge contributions</strong>
+          <Content component="p">
+            Knowledge contributions enable you to add new facts, data, or references into your model to enhance its ability to accurately answer
+            questions. Upload a document such as a textbook, technical manual, or journal, to get started.{' '}
+            {showSkillsInfo ? (
+              <Button variant="link" isInline onClick={() => router.push('/contribute/knowledge')}>
+                Create a knowledge contribution
+              </Button>
+            ) : null}
+          </Content>
+          {knowledgeOnly ? (
+            <>
+              <strong>Creating seed data</strong>
+              <Content component="p">
+                Seed data consist of a context, which is a portion of the selected document, and at least 5 question-and-answer (Q and A) pairs that
+                represent the knowledge you are trying to teach your model.
+              </Content>
+              <Content component="p">
+                The Q and A pairs that you create should be diverse. Rephrase questions in different ways, and create unique contexts.
+              </Content>
+              <Content component="p">
+                For example, when training a model to answer questions about a context that contains information about different species of birds and
+                their visual characteristics, don’t create Q and A pairs that only relate to finches. Doing so might unintentionally prevent the model
+                from answering questions about other bird species.
+              </Content>
+            </>
+          ) : null}
+          {showSkillsInfo ? (
+            <>
+              <strong>Skill contributions</strong>
+              <Content component="p">
+                Skill contributions improve a model’s ability to perform tasks, such as generating a song or summarizing an email. These contributions
+                consist of seed data which provide instructions for completing a task.{' '}
+                <Button variant="link" isInline onClick={() => router.push('/contribute/skill')}>
+                  Create a skill contribution
+                </Button>
+              </Content>
+            </>
+          ) : (
+            <>
+              <strong>Creating a knowledge contribution</strong>
+              <Content component="ul">
+                <Content component="li">
+                  Upload a document containing the desired data to the <strong>Documents</strong> page.
+                </Content>
+                <Content component="li">
+                  From the <strong>My contributions</strong> page, click <strong>Contribute</strong>.
+                </Content>
+                <Content component="li">
+                  Select a portion of the document to use as the context. This is the information that one of your question-and-answer (Q and A) pairs
+                  will be based on.
+                </Content>
+                <Content component="li">Create Q and A pairs that can be answered by the text in the context field.</Content>
+              </Content>
+            </>
+          )}
+        </div>
+      }
+    />
+  );
+};
+
+export default ContributionsSidePanelHelp;

--- a/src/components/SidePanelContents/CustomEndpointsSidePanelHelp.tsx
+++ b/src/components/SidePanelContents/CustomEndpointsSidePanelHelp.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { useRouter } from 'next/navigation';
+import { Button, Content } from '@patternfly/react-core';
+import SidePanelHelp from '@/components/SidePanelContents/SidePanelHelp';
+
+export const CustomEndpointsTitle = 'Custom model endpoints';
+
+export const CustomEndpointsDescription: React.FC = () => {
+  const router = useRouter();
+
+  return (
+    <>
+      Adding a custom model endpoint enables you to test a model on the{' '}
+      <Button variant="link" isInline onClick={() => router.push('/playground/chat')}>
+        Chat with a model
+      </Button>{' '}
+      page.
+    </>
+  );
+};
+
+export const CustomEndpointsBody: React.FC = () => {
+  const router = useRouter();
+
+  return (
+    <>
+      <strong>Adding endpoints</strong>
+      <Content component="p">
+        To add an endpoint, click the <strong>Add custom model endpoint</strong> button on the{' '}
+        <Button variant="link" isInline onClick={() => router.push('/playground/endpoints')}>
+          Custom model endpoints
+        </Button>{' '}
+        or{' '}
+        <Button variant="link" isInline onClick={() => router.push('/playground/chat')}>
+          Chat with a model
+        </Button>{' '}
+        page. Complete the required fields, such as URL and API key, then click <strong>Add</strong>. The new endpoint will be enabled automatically.
+      </Content>
+      <strong>Enabling and disabling endpoints</strong>
+      <Content component="p">
+        You can control when models are exposed for inference. Enabling an endpoint makes a model available for querying, while disabling it prevents
+        requests from reaching the model.
+      </Content>
+    </>
+  );
+};
+
+const CustomEndpointsSidePanelHelp: React.FC = () => (
+  <SidePanelHelp header={CustomEndpointsTitle} description={<CustomEndpointsDescription />} body={<CustomEndpointsBody />} />
+);
+
+export default CustomEndpointsSidePanelHelp;

--- a/src/components/SidePanelContents/DocumentsSidePanelHelp.tsx
+++ b/src/components/SidePanelContents/DocumentsSidePanelHelp.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import ContributionsSidePanelHelp from '@/components/SidePanelContents/ContributionsSidePanelHelp';
+
+const DocumentsSidePanelHelp: React.FC = () => <ContributionsSidePanelHelp knowledgeOnly />;
+
+export default DocumentsSidePanelHelp;

--- a/src/components/SidePanelContents/KnowledgeContributionSidePanelHelp.tsx
+++ b/src/components/SidePanelContents/KnowledgeContributionSidePanelHelp.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import ContributionsSidePanelHelp from '@/components/SidePanelContents/ContributionsSidePanelHelp';
+
+const KnowledgeContributionSidePanelHelp: React.FC = () => <ContributionsSidePanelHelp knowledgeOnly />;
+
+export default KnowledgeContributionSidePanelHelp;

--- a/src/components/SidePanelContents/SidePanelContents.scss
+++ b/src/components/SidePanelContents/SidePanelContents.scss
@@ -1,0 +1,11 @@
+.side-panel-contents {
+  .pf-v6-c-content--li {
+    line-height: 1.1em;
+    &:first-of-type {
+      padding-top: var(--pf-t--global--spacer--xs);
+    }
+  }
+  .second-level-list {
+    margin: 0 !important;
+  }
+}

--- a/src/components/SidePanelContents/SidePanelHelp.tsx
+++ b/src/components/SidePanelContents/SidePanelHelp.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import {
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerContentBody,
+  DrawerHead,
+  DrawerPanelContent,
+  DrawerPanelDescription,
+  Title
+} from '@patternfly/react-core';
+import { useSideDrawer } from '@/context/SideDrawerContext';
+
+import './SidePanelContents.scss';
+
+interface Props {
+  header: React.ReactNode;
+  actions?: React.ReactNode;
+  description?: React.ReactNode;
+  body: React.ReactNode;
+}
+const SidePanelHelp: React.FC<Props> = ({ header, actions, description, body }) => {
+  const sideDrawerContext = useSideDrawer();
+
+  return (
+    <DrawerPanelContent isResizable defaultSize={'300px'} minSize={'150px'}>
+      <DrawerHead>
+        <Title headingLevel="h2">{header}</Title>
+        <DrawerActions>
+          {actions}
+          <DrawerCloseButton onClick={() => sideDrawerContext.close()} />
+        </DrawerActions>
+      </DrawerHead>
+      {description ? <DrawerPanelDescription>{description}</DrawerPanelDescription> : null}
+      <DrawerContentBody className="side-panel-contents">{body}</DrawerContentBody>
+    </DrawerPanelContent>
+  );
+};
+
+export default SidePanelHelp;

--- a/src/components/SidePanelContents/SkillContributionSidePanelHelp.tsx
+++ b/src/components/SidePanelContents/SkillContributionSidePanelHelp.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { Content } from '@patternfly/react-core';
+import SidePanelHelp from '@/components/SidePanelContents/SidePanelHelp';
+
+const ContributionsSidePanelHelp: React.FC = () => {
+  return (
+    <SidePanelHelp
+      header="Skill contributions"
+      description="Skill contributions improve a model’s ability to perform tasks, such as generating a song or summarizing an email. These contributions consist of seed data which provide instructions for completing a task. There are 2 types of skills: freeform and grounded."
+      body={
+        <div>
+          <strong>Freeform skills</strong>
+          <Content component="p">Freeform skills are performative and do not require additional context.</Content>
+          <Content component="p">
+            For example, if you want to teach a model to summarize, you might provide a long paragraph in the <strong>Context</strong> field. You
+            might enter &quot;Can you summarize this paragraph?&quot; as the question, and enter a short summary of the paragraph in the context field
+            for the answer.
+          </Content>
+          <Content>Freeform skill examples:</Content>
+          <Content component="ul">
+            <Content component="li">Speak like Yoda</Content>
+            <Content component="li">Convert text to camel case</Content>
+            <Content component="li">Write a haiku</Content>
+            <Content component="li">Generate StableDiffusion prompts</Content>
+          </Content>
+          <strong>Grounded skills</strong>
+          <Content component="p">Grounded skills are performative and require additional context.</Content>
+          <Content component="p">
+            For example, if you want to teach a model to read a Markdown-formatted table layout, the additional context might be an example table
+            layout. This additional context is included in the skill contribution YAML.
+          </Content>
+          <Content>Grounded skill examples:</Content>
+          <Content component="ul">
+            <Content component="li">Read the value of a cell in a table layout</Content>
+            <Content component="li">Parse a JSON file</Content>
+          </Content>
+          <strong>Creating seed data</strong>
+          <Content component="p">
+            Seed data consist of at least 5 question-and-answer (Q and A) pairs that represent the skill you are trying to teach your model. If your
+            skill is a grounded skill and requires context, you will also add context for each question-and-answer pair.
+          </Content>
+          <Content component="p">
+            The Q and A pairs that you create should be diverse. Rephrase questions in different ways, and create unique contexts.
+          </Content>
+          <Content component="p">
+            For example, when training a model to perform data extraction using Beancount, don’t use the same data repeatedly in your seed examples.
+            Doing so might unintentionally teach the model to regurgitate the input data when asked a data extraction question.
+          </Content>
+          <strong>Creating a skill contribution</strong>
+          <Content component="ul">
+            <Content component="li">
+              From the <strong>My contributions</strong> page, click <strong>Contribute skill</strong>.
+            </Content>
+            <Content component="li">
+              In the <strong>Context</strong> field, provide a piece of content that you can create question-and-answer pairs based on.
+            </Content>
+            <Content component="ul" className="second-level-list">
+              <Content component="li">
+                For example, if you want to teach the model how to summarize, you might provide a long paragraph in the context field.
+              </Content>
+            </Content>
+            <Content component="li">
+              In the <strong>Question</strong> field, enter a prompt that the model will respond to.
+            </Content>
+            <Content component="ul" className="second-level-list">
+              <Content component="li">For example, the question might be “Can you summarize this text?”</Content>
+            </Content>
+            <Content component="li">
+              In the <strong>Answer</strong> field, enter a response to the question you provided.
+            </Content>
+            <Content component="ul" className="second-level-list">
+              <Content component="li">
+                For example, the answer might be a brief summary of the text that you entered in the <strong>Context</strong> field.
+              </Content>
+            </Content>
+          </Content>
+        </div>
+      }
+    />
+  );
+};
+
+export default ContributionsSidePanelHelp;

--- a/src/context/SideDrawerContext.tsx
+++ b/src/context/SideDrawerContext.tsx
@@ -1,0 +1,28 @@
+// src/context/ThemeContext.tsx
+'use client';
+
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+interface SideDrawerContext {
+  sideDrawerContent: React.ReactNode | null;
+  setSideDrawerContent: (content: React.ReactNode) => void;
+  close: () => void;
+}
+
+const SideDrawerContext = createContext<SideDrawerContext | undefined>(undefined);
+
+export const SideDrawerProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [sideDrawerContent, setSideDrawerContent] = useState<React.ReactNode | null>(null);
+
+  const close = React.useCallback(() => setSideDrawerContent(null), []);
+
+  return <SideDrawerContext.Provider value={{ sideDrawerContent, setSideDrawerContent, close }}>{children}</SideDrawerContext.Provider>;
+};
+
+export const useSideDrawer = () => {
+  const context = useContext(SideDrawerContext);
+  if (!context) {
+    throw new Error('useSideDrawer must be used within a SideDrawerProvider');
+  }
+  return context;
+};

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -15,10 +15,10 @@
 
 /* Custom class to make PatternFly Labels square */
 .square-label.pf-c-label {
-  border-radius: 0px !important;
+  border-radius: 0 !important;
 }
 
-.destructive-action-item {
+.pf-v6-c-menu__list-item.destructive-action-item:not(.pf-m-disabled) {
   .pf-v6-c-menu__item-text {
     color: var(--pf-t--global--color--status--danger--100);
   }


### PR DESCRIPTION
Fixes [[Dev] In-app documentation for 1.5](https://github.com/instructlab/ui/issues/793)

### Description
Add in-app documentation for pages and content updates

### Screen shots

#### Updated confirmation modals
![image](https://github.com/user-attachments/assets/2ee08f37-2c9c-406d-9d0f-83eedee6bf35)


![image](https://github.com/user-attachments/assets/fac5616f-efce-4d34-aaa1-5f7d4966b5a2)


![image](https://github.com/user-attachments/assets/9c376e89-4598-4ea8-93ca-67d5484c5404)


#### Dashboard (Skills not enabled)
![image](https://github.com/user-attachments/assets/e911f3b9-48dc-4658-8534-f3ab02c490ba)


#### Dashboard (Skills enabled)
![image](https://github.com/user-attachments/assets/1299d8d4-1f66-40d8-a200-2f9e05a768bf)


#### Documents
![image](https://github.com/user-attachments/assets/746d9aa1-6dca-4d3d-9d4f-db78b3ec5530)


#### Knowledge contributions
![image](https://github.com/user-attachments/assets/2e381708-c855-40ff-a2b2-0fa42e449ecf)


#### Skill contributions
![image](https://github.com/user-attachments/assets/aec936b6-761f-4be5-985e-a934fc89fc3a)


![image](https://github.com/user-attachments/assets/54df48c8-3ccd-4066-9095-97fb52ed9409)


#### Chat with a model
![image](https://github.com/user-attachments/assets/ecb93724-b7e5-44b5-ad1d-4d698af6552c)


#### Custom model endpoints
![image](https://github.com/user-attachments/assets/dd526d40-773d-4809-8b2a-717d6636d65b)


/cc @kaedward