### PR TITLE
Add ability to turn on feature flags via search param 'devFeatureFlags'

### DIFF
--- a/src/app/contribute/skill/[...slug]/page.tsx
+++ b/src/app/contribute/skill/[...slug]/page.tsx
@@ -1,6 +1,6 @@
 // src/app/contribute/skill/[...slug]/page.tsx
 import * as React from 'react';
-import { AppLayout } from '@/components/AppLayout';
+import { AppLayout, FeaturePages } from '@/components/AppLayout';
 import ViewSkillPage from '@/components/Contribute/Skill/View/ViewSkillPage';
 
 type PageProps = {
@@ -11,7 +11,7 @@ const SkillViewPage = async ({ params }: PageProps) => {
   const resolvedParams = await params;
 
   return (
-    <AppLayout className="contribute-page">
+    <AppLayout className="contribute-page" requiredFeature={FeaturePages.Skill}>
       <ViewSkillPage branchName={resolvedParams.slug[0]} isDraft={resolvedParams.slug[1] === 'isDraft'} />
     </AppLayout>
   );

--- a/src/app/contribute/skill/edit/[...slug]/page.tsx
+++ b/src/app/contribute/skill/edit/[...slug]/page.tsx
@@ -1,6 +1,6 @@
 // src/app/contribute/skill/edit/[...slug]/page.tsx
 import * as React from 'react';
-import { AppLayout } from '@/components/AppLayout';
+import { AppLayout, FeaturePages } from '@/components/AppLayout';
 import EditSkill from '@/components/Contribute/Skill/Edit/EditSkill';
 
 type PageProps = {
@@ -11,7 +11,7 @@ const EditSkillPage = async ({ params }: PageProps) => {
   const resolvedParams = await params;
 
   return (
-    <AppLayout className="contribute-page">
+    <AppLayout className="contribute-page" requiredFeature={FeaturePages.Skill}>
       <EditSkill branchName={resolvedParams.slug[0]} isDraft={resolvedParams.slug[1] === 'isDraft'} />
     </AppLayout>
   );

--- a/src/app/contribute/skill/page.tsx
+++ b/src/app/contribute/skill/page.tsx
@@ -1,11 +1,11 @@
 // src/app/contribute/skill/page.tsx
 'use client';
 import React from 'react';
-import { AppLayout } from '@/components/AppLayout';
+import { AppLayout, FeaturePages } from '@/components/AppLayout';
 import SkillForm from '@/components/Contribute/Skill/Edit/SkillForm';
 
 const AddSkillPage: React.FunctionComponent = () => (
-  <AppLayout className="contribute-page">
+  <AppLayout className="contribute-page" requiredFeature={FeaturePages.Skill}>
     <SkillForm />
   </AppLayout>
 );

--- a/src/app/experimental/chat-eval/page.tsx
+++ b/src/app/experimental/chat-eval/page.tsx
@@ -3,12 +3,12 @@
 
 import * as React from 'react';
 import '@patternfly/react-core/dist/styles/base.css';
-import { AppLayout } from '@/components/AppLayout';
+import { AppLayout, FeaturePages } from '@/components/AppLayout';
 import ChatEval from '@/components/Experimental/ChatEval/ChatEval';
 
 const ChatEvalPage: React.FunctionComponent = () => {
   return (
-    <AppLayout className="chatBotPage">
+    <AppLayout className="chatBotPage" requiredFeature={FeaturePages.Experimental}>
       <ChatEval />
     </AppLayout>
   );

--- a/src/app/experimental/fine-tune/page.tsx
+++ b/src/app/experimental/fine-tune/page.tsx
@@ -3,12 +3,12 @@
 
 import * as React from 'react';
 import '@patternfly/react-core/dist/styles/base.css';
-import { AppLayout } from '@/components/AppLayout';
+import { AppLayout, FeaturePages } from '@/components/AppLayout';
 import FineTuning from '@/components/Experimental/FineTuning';
 
 const FineTune: React.FunctionComponent = () => {
   return (
-    <AppLayout>
+    <AppLayout requiredFeature={FeaturePages.Experimental}>
       <FineTuning />
     </AppLayout>
   );

--- a/src/app/playground/chat/page.tsx
+++ b/src/app/playground/chat/page.tsx
@@ -2,8 +2,8 @@
 'use client';
 
 import React from 'react';
-import { PageSection, Content } from '@patternfly/react-core/';
-import { AppLayout } from '@/components/AppLayout';
+import { Content, PageSection } from '@patternfly/react-core/';
+import { AppLayout, FeaturePages } from '@/components/AppLayout';
 import ChatPageSidePanelHelp from '@/components/SidePanelContents/ChatPageSidePanelHelp';
 import PageDescriptionWithHelp from '@/components/Common/PageDescriptionWithHelp';
 import ModelsContextProvider from '../../../components/Chat/ModelsContext';
@@ -11,23 +11,25 @@ import ChatBotContainer from '../../../components/Chat/ChatBotContainer';
 
 import './chatbotPage.css';
 
-const ChatPage: React.FC = () => (
-  <AppLayout className="chatBotPage">
-    <PageSection>
-      <Content component="h1">Chat with a model</Content>
-      <PageDescriptionWithHelp
-        description={`Before you start adding new skills and knowledge to your model, you can check its baseline
+const ChatPage: React.FC = () => {
+  return (
+    <AppLayout className="chatBotPage" requiredFeature={FeaturePages.Playground}>
+      <PageSection>
+        <Content component="h1">Chat with a model</Content>
+        <PageDescriptionWithHelp
+          description={`Before you start adding new skills and knowledge to your model, you can check its baseline
           performance by chatting with a language model that's hosted on your cloud. Choose a supported model
            from the model selector or configure your own custom endpoints to gain direct access
           to a specific model you've trained.`}
-        helpText="Learn more about chatting with models"
-        sidePanelContent={<ChatPageSidePanelHelp />}
-      />
-    </PageSection>
-    <ModelsContextProvider>
-      <ChatBotContainer />
-    </ModelsContextProvider>
-  </AppLayout>
-);
+          helpText="Learn more about chatting with models"
+          sidePanelContent={<ChatPageSidePanelHelp />}
+        />
+      </PageSection>
+      <ModelsContextProvider>
+        <ChatBotContainer />
+      </ModelsContextProvider>
+    </AppLayout>
+  );
+};
 
 export default ChatPage;

--- a/src/app/playground/endpoints/page.tsx
+++ b/src/app/playground/endpoints/page.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import {
   Button,
+  ClipboardCopy,
   Content,
   DataList,
   DataListAction,
@@ -14,13 +15,12 @@ import {
   Flex,
   FlexItem,
   PageSection,
-  Truncate,
-  ClipboardCopy
+  Truncate
 } from '@patternfly/react-core';
-import { BanIcon, CheckCircleIcon, EyeSlashIcon, EyeIcon, QuestionCircleIcon } from '@patternfly/react-icons';
+import { BanIcon, CheckCircleIcon, EyeIcon, EyeSlashIcon, QuestionCircleIcon } from '@patternfly/react-icons';
 import { Endpoint, ModelEndpointStatus } from '@/types';
 import { fetchEndpointStatus } from '@/services/modelService';
-import { AppLayout } from '@/components/AppLayout';
+import { AppLayout, FeaturePages } from '@/components/AppLayout';
 import CustomEndpointsSidePanelHelp from '@/components/SidePanelContents/CustomEndpointsSidePanelHelp';
 import EditEndpointModal from '@/app/playground/endpoints/EditEndpointModal';
 import DeleteEndpointModal from '@/app/playground/endpoints/DeleteEndpoinModal';
@@ -188,7 +188,7 @@ const EndpointsPage: React.FC = () => {
   };
 
   return (
-    <AppLayout>
+    <AppLayout requiredFeature={FeaturePages.Playground}>
       <PageSection>
         <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }} gap={{ default: 'gapMd' }}>
           <FlexItem>

--- a/src/components/Banner/DevFlagsBanner.tsx
+++ b/src/components/Banner/DevFlagsBanner.tsx
@@ -1,0 +1,50 @@
+// src/components/AppLayout.tsx
+'use client';
+
+import * as React from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { Banner, Flex, FlexItem, Button } from '@patternfly/react-core';
+import { useFeatureFlags } from '@/context/FeatureFlagsContext';
+
+const FEATURE_FLAG_PARAM = 'devFeatureFlags';
+
+const DevFlagsBanner: React.FC = () => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { devFeatureFlagsEnabled, setDevFeatureFlagsEnabled } = useFeatureFlags();
+
+  React.useEffect(() => {
+    const featureFlagParam = searchParams.get(FEATURE_FLAG_PARAM);
+    if (featureFlagParam !== null) {
+      setDevFeatureFlagsEnabled(true);
+    }
+  }, [searchParams, setDevFeatureFlagsEnabled]);
+
+  const disableFeatureFlags = () => {
+    setDevFeatureFlagsEnabled(false);
+
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete(FEATURE_FLAG_PARAM);
+    router.push(pathname + '?' + params.toString());
+  };
+
+  if (!devFeatureFlagsEnabled) {
+    return null;
+  }
+  return (
+    <Banner color="blue">
+      <Flex justifyContent={{ default: 'justifyContentSpaceAround' }}>
+        <FlexItem>
+          Feature flags are overridden in the current session.{' '}
+          <Button variant="link" isInline onClick={disableFeatureFlags}>
+            Click here
+          </Button>{' '}
+          to reset back to defaults.
+        </FlexItem>
+      </Flex>
+    </Banner>
+  );
+};
+
+export default DevFlagsBanner;

--- a/src/context/FeatureFlagsContext.tsx
+++ b/src/context/FeatureFlagsContext.tsx
@@ -2,9 +2,11 @@
 'use client';
 
 import React from 'react';
-import { devLog } from '@/utils/devlog';
 import { FeatureFlagsType } from '@/types';
+import { devLog } from '@/utils/devlog';
 import { fetchFeatureFlags } from '@/utils/featureFlagsService';
+
+const FEATURE_FLAGS_STORAGE_ITEM = 'IL_Feature_Flags';
 
 const DefaultFeatureFlags = {
   docConversionEnabled: false,
@@ -13,12 +15,30 @@ const DefaultFeatureFlags = {
   experimentalFeaturesEnabled: false
 };
 
-const FeatureFlagsContext = React.createContext<{ loaded: boolean; featureFlags: FeatureFlagsType }>({
+const AllFeatureFlags = {
+  docConversionEnabled: true,
+  skillFeaturesEnabled: true,
+  playgroundFeaturesEnabled: true,
+  experimentalFeaturesEnabled: true
+};
+
+interface FeatureFlagsContextType {
+  loaded: boolean;
+  featureFlags: FeatureFlagsType;
+  devFeatureFlagsEnabled: boolean;
+  setDevFeatureFlagsEnabled: (enabled: boolean) => void;
+}
+
+const FeatureFlagsContext = React.createContext<FeatureFlagsContextType>({
   loaded: false,
-  featureFlags: DefaultFeatureFlags
+  featureFlags: DefaultFeatureFlags,
+  devFeatureFlagsEnabled: false,
+  setDevFeatureFlagsEnabled: () => {}
 });
 
 export const FeatureFlagsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [envState, setEnvState] = React.useState<FeatureFlagsType>(DefaultFeatureFlags);
+  const [featureFlagsEnabled, setFeatureFlagsEnabled] = React.useState<boolean>(false);
   const [currentState, setCurrentState] = React.useState<{ loaded: boolean; featureFlags: FeatureFlagsType }>({
     loaded: false,
     featureFlags: { ...DefaultFeatureFlags }
@@ -26,19 +46,58 @@ export const FeatureFlagsProvider: React.FC<{ children: React.ReactNode }> = ({ 
 
   React.useEffect(() => {
     fetchFeatureFlags().then((newConfig) => {
-      devLog(`======== Feature Flags ============`);
-      devLog(`  docConversionEnabled: `, newConfig.docConversionEnabled);
-      devLog(`  skillFeaturesEnabled: `, newConfig.skillFeaturesEnabled);
-      devLog(`  playgroundFeaturesEnabled: `, newConfig.playgroundFeaturesEnabled);
-      devLog(`  experimentalFeaturesEnabled: `, newConfig.experimentalFeaturesEnabled);
+      devLog(`======== Env Feature Flags ============`);
+      devLog(JSON.stringify(newConfig, null, 2));
+      setEnvState(newConfig);
+
+      try {
+        const localStorageState = localStorage.getItem(FEATURE_FLAGS_STORAGE_ITEM);
+        if (localStorageState === 'true') {
+          setFeatureFlagsEnabled(true);
+          devLog(`======== Enabled All Feature Flags ============`);
+          devLog(JSON.stringify(AllFeatureFlags, null, 2));
+          setCurrentState({ loaded: true, featureFlags: AllFeatureFlags });
+          return;
+        }
+      } catch {
+        console.error(`Error parsing local storage for feature flags.`);
+      }
       setCurrentState({ loaded: true, featureFlags: newConfig });
     });
   }, []);
 
-  return <FeatureFlagsContext.Provider value={{ ...currentState }}>{children}</FeatureFlagsContext.Provider>;
+  const setDevFeatureFlagsEnabled = React.useCallback(
+    (enabled: boolean) => {
+      if (enabled) {
+        const allFeatureFlags = {
+          docConversionEnabled: true,
+          skillFeaturesEnabled: true,
+          playgroundFeaturesEnabled: true,
+          experimentalFeaturesEnabled: true
+        };
+        localStorage.setItem(FEATURE_FLAGS_STORAGE_ITEM, 'true');
+        setCurrentState({
+          loaded: true,
+          featureFlags: allFeatureFlags
+        });
+      } else {
+        setFeatureFlagsEnabled(false);
+        localStorage.removeItem(FEATURE_FLAGS_STORAGE_ITEM);
+        setCurrentState({ loaded: true, featureFlags: envState });
+      }
+      setFeatureFlagsEnabled(enabled);
+    },
+    [envState]
+  );
+
+  return (
+    <FeatureFlagsContext.Provider value={{ ...currentState, setDevFeatureFlagsEnabled, devFeatureFlagsEnabled: featureFlagsEnabled }}>
+      {children}
+    </FeatureFlagsContext.Provider>
+  );
 };
 
-export const useFeatureFlags = (): { loaded: boolean; featureFlags: FeatureFlagsType } => {
+export const useFeatureFlags = (): FeatureFlagsContextType => {
   const context = React.useContext(FeatureFlagsContext);
   if (!context) {
     throw new Error('useEnvConfig must be used within a EnvConfigProvider');


### PR DESCRIPTION
### Description

Adds the ability to enable all feature flags by adding `?devFeatureFlags` (`&devFeatureFlags` if search params already exist) to the URL.

Adds checks to ensure pages that are disabled are not shown if the user happens to know the URL to the page.

When On a banner is shown indicating the feature flags have been enabled and a button to turn the feature flags back to their original state (from the .env file).

### Screen shot
![image](https://github.com/user-attachments/assets/5fed8dee-d19d-4b21-baf4-baecde31b86f)
