### PR TITLE
Simplify navigation for draft contributions

### DIFF
--- a/src/app/contribute/knowledge/[...slug]/page.tsx
+++ b/src/app/contribute/knowledge/[...slug]/page.tsx
@@ -12,7 +12,7 @@ const KnowledgeViewPage = async ({ params }: PageProps) => {
 
   return (
     <AppLayout className="contribute-page">
-      <ViewKnowledgePage branchName={resolvedParams.slug[0]} isDraft={resolvedParams.slug[1] === 'isDraft'} />
+      <ViewKnowledgePage branchName={resolvedParams.slug[0]} />
     </AppLayout>
   );
 };

--- a/src/app/contribute/knowledge/edit/[...slug]/page.tsx
+++ b/src/app/contribute/knowledge/edit/[...slug]/page.tsx
@@ -12,7 +12,7 @@ const EditKnowledgePage = async ({ params }: PageProps) => {
 
   return (
     <AppLayout className="contribute-page">
-      <EditKnowledge branchName={resolvedParams.slug[0]} isDraft={resolvedParams.slug[1] === 'isDraft'} />
+      <EditKnowledge branchName={resolvedParams.slug[0]} />
     </AppLayout>
   );
 };

--- a/src/app/contribute/skill/[...slug]/page.tsx
+++ b/src/app/contribute/skill/[...slug]/page.tsx
@@ -12,7 +12,7 @@ const SkillViewPage = async ({ params }: PageProps) => {
 
   return (
     <AppLayout className="contribute-page" requiredFeature={FeaturePages.Skill}>
-      <ViewSkillPage branchName={resolvedParams.slug[0]} isDraft={resolvedParams.slug[1] === 'isDraft'} />
+      <ViewSkillPage branchName={resolvedParams.slug[0]} />
     </AppLayout>
   );
 };

--- a/src/app/contribute/skill/edit/[...slug]/page.tsx
+++ b/src/app/contribute/skill/edit/[...slug]/page.tsx
@@ -12,7 +12,7 @@ const EditSkillPage = async ({ params }: PageProps) => {
 
   return (
     <AppLayout className="contribute-page" requiredFeature={FeaturePages.Skill}>
-      <EditSkill branchName={resolvedParams.slug[0]} isDraft={resolvedParams.slug[1] === 'isDraft'} />
+      <EditSkill branchName={resolvedParams.slug[0]} />
     </AppLayout>
   );
 };

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,7 +2,6 @@
 'use client';
 
 import React from 'react';
-import '@patternfly/react-core/dist/styles/base.css';
 import { AppLayout } from '@/components/AppLayout';
 import DashboardPage from '@/components/Dashboard/DashboardPage';
 

--- a/src/app/documents/page.tsx
+++ b/src/app/documents/page.tsx
@@ -2,7 +2,6 @@
 'use client';
 
 import React from 'react';
-import '@patternfly/react-core/dist/styles/base.css';
 import { AppLayout } from '@/components/AppLayout';
 import Documents from '@/components/Documents/Documents';
 

--- a/src/app/experimental/chat-eval/page.tsx
+++ b/src/app/experimental/chat-eval/page.tsx
@@ -2,7 +2,6 @@
 'use client';
 
 import * as React from 'react';
-import '@patternfly/react-core/dist/styles/base.css';
 import { AppLayout, FeaturePages } from '@/components/AppLayout';
 import ChatEval from '@/components/Experimental/ChatEval/ChatEval';
 

--- a/src/app/experimental/fine-tune/page.tsx
+++ b/src/app/experimental/fine-tune/page.tsx
@@ -2,7 +2,6 @@
 'use client';
 
 import * as React from 'react';
-import '@patternfly/react-core/dist/styles/base.css';
 import { AppLayout, FeaturePages } from '@/components/AppLayout';
 import FineTuning from '@/components/Experimental/FineTuning/FineTuningJobs';
 

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -2,16 +2,8 @@
 'use client';
 
 import * as React from 'react';
-import { ThemeProvider } from '../context/ThemeContext';
-import '@patternfly/react-core/dist/styles/base.css';
-import Dashboard from './dashboard/page';
+import DashboardPage from './dashboard/page';
 
-const Home: React.FunctionComponent = () => {
-  return (
-    <ThemeProvider>
-      <Dashboard />
-    </ThemeProvider>
-  );
-};
+const Home: React.FunctionComponent = () => <DashboardPage />;
 
 export default Home;

--- a/src/components/Contribute/ContributePageHeader.tsx
+++ b/src/components/Contribute/ContributePageHeader.tsx
@@ -4,8 +4,9 @@
 import * as React from 'react';
 import { useRouter } from 'next/navigation';
 import { PageSection, Flex, FlexItem, Title, PageBreadcrumb, Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
-import { EditFormData, KnowledgeFormData, SkillFormData } from '@/types';
+import { ContributionFormData, EditFormData, KnowledgeFormData, SkillFormData } from '@/types';
 import PageDescriptionWithHelp from '@/components/Common/PageDescriptionWithHelp';
+import { isDraftDataExist } from '@/components/Contribute/Utils/autoSaveUtils';
 import {
   DraftContributionLabel,
   KnowledgeContributionLabel,
@@ -15,6 +16,7 @@ import {
 
 interface Props {
   editFormData?: EditFormData<SkillFormData | KnowledgeFormData>;
+  draftData?: ContributionFormData;
   isEdit?: boolean;
   isSkill?: boolean;
   description: React.ReactNode;
@@ -25,6 +27,7 @@ interface Props {
 
 const ContributePageHeader: React.FC<Props> = ({
   editFormData,
+  draftData,
   isEdit = false,
   isSkill = false,
   description,
@@ -33,9 +36,10 @@ const ContributePageHeader: React.FC<Props> = ({
   actions
 }) => {
   const router = useRouter();
+  const currentData = draftData || editFormData?.formData;
   const contributionType = isSkill ? 'skill' : 'knowledge';
-  const viewUrl = `/contribute/${isSkill ? 'skill' : 'knowledge'}/${editFormData?.formData.branchName}${editFormData?.isDraft ? '/isDraft' : ''}`;
-  const contributionTitle = editFormData?.formData?.submissionSummary || `Draft ${contributionType} contribution`;
+  const viewUrl = `/contribute/${isSkill ? 'skill' : 'knowledge'}/${currentData?.branchName}`;
+  const contributionTitle = currentData?.submissionSummary || `Draft ${contributionType} contribution`;
 
   return (
     <>
@@ -58,9 +62,7 @@ const ContributePageHeader: React.FC<Props> = ({
                 router.push(viewUrl);
               }}
             >
-              {!editFormData
-                ? `Contribute ${contributionType}`
-                : editFormData?.formData?.submissionSummary || `Draft ${contributionType} contribution`}
+              {!editFormData ? `Contribute ${contributionType}` : currentData?.submissionSummary || `Draft ${contributionType} contribution`}
             </BreadcrumbItem>
           ) : null}
           <BreadcrumbItem isActive>
@@ -78,16 +80,16 @@ const ContributePageHeader: React.FC<Props> = ({
                     <Title headingLevel="h1" size="2xl">
                       {!editFormData
                         ? `Submit ${contributionType} contribution`
-                        : editFormData?.formData?.submissionSummary || `Draft ${isSkill ? 'skill' : 'knowledge'} contribution`}
+                        : currentData?.submissionSummary || `Draft ${isSkill ? 'skill' : 'knowledge'} contribution`}
                     </Title>
                   </FlexItem>
                   <FlexItem>{isSkill ? <SkillContributionLabel /> : <KnowledgeContributionLabel />}</FlexItem>
-                  {editFormData?.isDraft ? (
+                  {currentData && isDraftDataExist(currentData.branchName) ? (
                     <FlexItem>
                       <DraftContributionLabel />
                     </FlexItem>
                   ) : null}
-                  {editFormData && !editFormData.isSubmitted ? (
+                  {!editFormData ? (
                     <FlexItem>
                       <NewContributionLabel isCompact={false} />
                     </FlexItem>

--- a/src/components/Contribute/Knowledge/KnowledgeFormActions.tsx
+++ b/src/components/Contribute/Knowledge/KnowledgeFormActions.tsx
@@ -215,9 +215,7 @@ export const KnowledgeFormActions: React.FunctionComponent<Props> = ({
         <DropdownList>
           {isDevMode && setKnowledgeFormData ? <DropdownItem onClick={autoFillForm}>Autofill</DropdownItem> : null}
           {!setKnowledgeFormData ? (
-            <DropdownItem onClick={() => router.push(`/contribute/knowledge/edit/${knowledgeFormData.branchName}${isDraft ? '/isDraft' : ''}`)}>
-              Edit contribution
-            </DropdownItem>
+            <DropdownItem onClick={() => router.push(`/contribute/knowledge/edit/${knowledgeFormData.branchName}`)}>Edit contribution</DropdownItem>
           ) : null}
           {setKnowledgeFormData ? <DropdownItem onClick={() => setIsUploadYamlModalOpen(true)}>Upload YAML</DropdownItem> : null}
           <DropdownItem onClick={() => handleViewYaml()}>View YAML</DropdownItem>

--- a/src/components/Contribute/Knowledge/View/ViewKnowledge.tsx
+++ b/src/components/Contribute/Knowledge/View/ViewKnowledge.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import * as React from 'react';
-import { KnowledgeEditFormData } from '@/types';
+import { KnowledgeEditFormData, KnowledgeFormData } from '@/types';
 import {
   PageSection,
   Flex,
@@ -15,6 +15,7 @@ import {
 import KnowledgeContributionSidePanelHelp from '@/components/SidePanelContents/KnowledgeContributionSidePanelHelp';
 import ViewContributionSection from '@/components/Common/ViewContributionSection';
 import { ActionGroupAlertContent } from '@/components/Contribute/types';
+import { isDraftDataExist } from '@/components/Contribute/Utils/autoSaveUtils';
 import ContributePageHeader from '@/components/Contribute/ContributePageHeader';
 import ContributeAlertGroup from '@/components/Contribute/ContributeAlertGroup';
 import KnowledgeFormActions from '@/components/Contribute/Knowledge/KnowledgeFormActions';
@@ -23,28 +24,35 @@ import KnowledgeSeedExampleCard from '@/components/Contribute/Knowledge/Knowledg
 import '../knowledge.css';
 
 interface ViewKnowledgeProps {
-  knowledgeEditFormData: KnowledgeEditFormData;
+  knowledgeEditFormData?: KnowledgeEditFormData;
+  draftData?: KnowledgeFormData;
 }
 
-const ViewKnowledge: React.FC<ViewKnowledgeProps> = ({ knowledgeEditFormData }) => {
+const ViewKnowledge: React.FC<ViewKnowledgeProps> = ({ knowledgeEditFormData, draftData }) => {
   const [actionGroupAlertContent, setActionGroupAlertContent] = React.useState<ActionGroupAlertContent | undefined>();
   const [scrollableRef, setScrollableRef] = React.useState<HTMLElement | null>();
   const [bodyRef, setBodyRef] = React.useState<HTMLElement | null>();
+  const currentData = draftData || knowledgeEditFormData?.formData;
+
+  if (!currentData) {
+    return null;
+  }
 
   return (
     <PageGroup isFilled style={{ overflowY: 'hidden', flex: 1 }}>
       <ContributePageHeader
         editFormData={knowledgeEditFormData}
+        draftData={draftData}
         description="Knowledge contributions improve a model’s ability to answer questions accurately. They consist of questions and answers, and documents
               which back up that data."
         sidePanelContent={<KnowledgeContributionSidePanelHelp />}
         helpText="Learn more about knowledge contributions"
         actions={
           <KnowledgeFormActions
-            contributionTitle={knowledgeEditFormData.formData.submissionSummary}
-            knowledgeFormData={knowledgeEditFormData.formData}
-            isDraft={knowledgeEditFormData.isDraft}
-            isSubmitted={knowledgeEditFormData.isSubmitted}
+            contributionTitle={currentData.submissionSummary}
+            knowledgeFormData={currentData}
+            isDraft={isDraftDataExist(currentData.branchName)}
+            isSubmitted={!!knowledgeEditFormData}
             setActionGroupAlertContent={setActionGroupAlertContent}
           />
         }
@@ -61,8 +69,8 @@ const ViewKnowledge: React.FC<ViewKnowledgeProps> = ({ knowledgeEditFormData }) 
                   <DescriptionListGroup key="contributors">
                     <DescriptionListTerm>Contributors</DescriptionListTerm>
                     <DescriptionListDescription>
-                      <div>{knowledgeEditFormData.formData.name}</div>
-                      <div>{knowledgeEditFormData.formData.email}</div>
+                      <div>{currentData.name}</div>
+                      <div>{currentData.email}</div>
                     </DescriptionListDescription>
                   </DescriptionListGroup>
                 ]}
@@ -77,13 +85,13 @@ const ViewKnowledge: React.FC<ViewKnowledgeProps> = ({ knowledgeEditFormData }) 
                   <DescriptionListGroup key="submission-summary">
                     <DescriptionListTerm>Contribution summary</DescriptionListTerm>
                     <DescriptionListDescription>
-                      <div>{knowledgeEditFormData.formData.submissionSummary}</div>
+                      <div>{currentData.submissionSummary}</div>
                     </DescriptionListDescription>
                   </DescriptionListGroup>,
                   <DescriptionListGroup key="file-path">
                     <DescriptionListTerm>Directory path</DescriptionListTerm>
                     <DescriptionListDescription>
-                      <div>{knowledgeEditFormData.formData.filePath}</div>
+                      <div>{currentData.filePath}</div>
                     </DescriptionListDescription>
                   </DescriptionListGroup>
                 ]}
@@ -100,7 +108,7 @@ const ViewKnowledge: React.FC<ViewKnowledgeProps> = ({ knowledgeEditFormData }) 
                     <DescriptionListTerm>Examples</DescriptionListTerm>
                     <DescriptionListDescription>
                       <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }} ref={setBodyRef}>
-                        {knowledgeEditFormData.formData.seedExamples?.map((seedExample, index) => (
+                        {currentData.seedExamples?.map((seedExample, index) => (
                           <FlexItem key={`seed-${index}`}>
                             <KnowledgeSeedExampleCard
                               isReadOnly

--- a/src/components/Contribute/Knowledge/View/ViewKnowledgePage.tsx
+++ b/src/components/Contribute/Knowledge/View/ViewKnowledgePage.tsx
@@ -3,7 +3,7 @@
 
 import * as React from 'react';
 import { useSession } from 'next-auth/react';
-import { KnowledgeEditFormData } from '@/types';
+import { KnowledgeEditFormData, KnowledgeFormData } from '@/types';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Modal, ModalVariant, ModalBody } from '@patternfly/react-core';
@@ -13,41 +13,44 @@ import ViewKnowledge from '@/components/Contribute/Knowledge/View/ViewKnowledge'
 
 interface Props {
   branchName: string;
-  isDraft: boolean;
 }
 
-const ViewKnowledgePage: React.FC<Props> = ({ branchName, isDraft }) => {
+const ViewKnowledgePage: React.FC<Props> = ({ branchName }) => {
   const router = useRouter();
   const { data: session } = useSession();
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [loadingMsg, setLoadingMsg] = useState<string>('');
-  const [knowledgeEditFormData, setKnowledgeEditFormData] = useState<KnowledgeEditFormData>();
+  const [knowledgeData, setKnowledgeData] = useState<{ draftData?: KnowledgeFormData; editFormData?: KnowledgeEditFormData }>();
 
   useEffect(() => {
-    if (isDraft) {
-      fetchDraftKnowledgeChanges({ branchName, setIsLoading, setLoadingMsg, setKnowledgeEditFormData });
-      return;
-    }
-
-    setLoadingMsg('Fetching knowledge data from branch : ' + branchName);
+    setLoadingMsg('Fetching knowledge data');
     const fetchFormData = async () => {
+      const draftData = fetchDraftKnowledgeChanges(branchName);
+
       const { editFormData, error } = await fetchKnowledgeBranchChanges(session, branchName);
-      if (error) {
+      if (error && !draftData) {
         setLoadingMsg(error);
         return;
       }
+
+      // If there is only one associated knowledge file, set it for each seed example
+      if (editFormData?.formData.uploadedFiles.length === 1) {
+        editFormData.formData.seedExamples.forEach((seedExample) => (seedExample.knowledgeFile = editFormData?.formData.uploadedFiles[0]));
+      }
+
       setIsLoading(false);
-      setKnowledgeEditFormData(editFormData);
+      setKnowledgeData({ draftData, editFormData });
     };
+
     fetchFormData();
-  }, [branchName, isDraft, session]);
+  }, [branchName, session]);
 
   const handleOnClose = () => {
     router.push('/dashboard');
     setIsLoading(false);
   };
 
-  if (isLoading || !knowledgeEditFormData?.formData) {
+  if (isLoading || (!knowledgeData?.editFormData && !knowledgeData?.draftData)) {
     return (
       <Modal variant={ModalVariant.small} title="Loading Knowledge Data" isOpen={isLoading} onClose={() => handleOnClose()}>
         <ModalBody>
@@ -57,7 +60,7 @@ const ViewKnowledgePage: React.FC<Props> = ({ branchName, isDraft }) => {
     );
   }
 
-  return <ViewKnowledge knowledgeEditFormData={knowledgeEditFormData} />;
+  return <ViewKnowledge knowledgeEditFormData={knowledgeData.editFormData} draftData={knowledgeData?.draftData} />;
 };
 
 export default ViewKnowledgePage;

--- a/src/components/Contribute/Skill/SkillFormActions.tsx
+++ b/src/components/Contribute/Skill/SkillFormActions.tsx
@@ -207,9 +207,7 @@ export const SkillFormActions: React.FunctionComponent<Props> = ({
         <DropdownList>
           {isDevMode && setSkillFormData ? <DropdownItem onClick={autoFillForm}>Autofill</DropdownItem> : null}
           {!setSkillFormData ? (
-            <DropdownItem onClick={() => router.push(`/contribute/skill/edit/${skillFormData.branchName}${isDraft ? '/isDraft' : ''}`)}>
-              Edit contribution
-            </DropdownItem>
+            <DropdownItem onClick={() => router.push(`/contribute/skill/edit/${skillFormData.branchName}`)}>Edit contribution</DropdownItem>
           ) : null}
           {setSkillFormData ? <DropdownItem onClick={() => setIsUploadYamlModalOpen(true)}>Upload YAML</DropdownItem> : null}
           <DropdownItem onClick={() => handleViewYaml()}>View YAML</DropdownItem>

--- a/src/components/Contribute/Skill/View/ViewSkill.tsx
+++ b/src/components/Contribute/Skill/View/ViewSkill.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import * as React from 'react';
-import { SkillEditFormData } from '@/types';
+import { SkillEditFormData, SkillFormData } from '@/types';
 import {
   PageSection,
   Flex,
@@ -21,11 +21,17 @@ import SkillFormActions from '@/components/Contribute/Skill/SkillFormActions';
 import SkillSeedExamples from '@/components/Contribute/Skill/View/SkillSeedExamples/SkillSeedExamples';
 
 interface ViewSkillProps {
-  skillEditFormData: SkillEditFormData;
+  skillEditFormData?: SkillEditFormData;
+  draftData?: SkillFormData;
 }
 
-const ViewSkill: React.FC<ViewSkillProps> = ({ skillEditFormData }) => {
+const ViewSkill: React.FC<ViewSkillProps> = ({ skillEditFormData, draftData }) => {
   const [actionGroupAlertContent, setActionGroupAlertContent] = React.useState<ActionGroupAlertContent | undefined>();
+  const currentData = draftData || skillEditFormData?.formData;
+
+  if (!currentData) {
+    return null;
+  }
 
   return (
     <PageGroup isFilled style={{ overflowY: 'hidden', flex: 1 }}>
@@ -38,10 +44,10 @@ const ViewSkill: React.FC<ViewSkillProps> = ({ skillEditFormData }) => {
         helpText="Learn more about skill contributions"
         actions={
           <SkillFormActions
-            contributionTitle={skillEditFormData.formData.submissionSummary}
-            skillFormData={skillEditFormData.formData}
-            isDraft={skillEditFormData?.isDraft}
-            isSubmitted={skillEditFormData?.isSubmitted}
+            contributionTitle={currentData.submissionSummary}
+            skillFormData={currentData}
+            isDraft={!!draftData}
+            isSubmitted={!!skillEditFormData?.formData}
             setActionGroupAlertContent={setActionGroupAlertContent}
           />
         }
@@ -57,8 +63,8 @@ const ViewSkill: React.FC<ViewSkillProps> = ({ skillEditFormData }) => {
                 <DescriptionListGroup key="contributors">
                   <DescriptionListTerm>Contributors</DescriptionListTerm>
                   <DescriptionListDescription>
-                    <div>{skillEditFormData.formData.name}</div>
-                    <div>{skillEditFormData.formData.email}</div>
+                    <div>{currentData.name}</div>
+                    <div>{currentData.email}</div>
                   </DescriptionListDescription>
                 </DescriptionListGroup>
               ]}
@@ -73,13 +79,13 @@ const ViewSkill: React.FC<ViewSkillProps> = ({ skillEditFormData }) => {
                 <DescriptionListGroup key="submission-summary">
                   <DescriptionListTerm>Contribution summary</DescriptionListTerm>
                   <DescriptionListDescription>
-                    <div>{skillEditFormData.formData.submissionSummary}</div>
+                    <div>{currentData.submissionSummary}</div>
                   </DescriptionListDescription>
                 </DescriptionListGroup>,
                 <DescriptionListGroup key="file-path">
                   <DescriptionListTerm>Directory path</DescriptionListTerm>
                   <DescriptionListDescription>
-                    <div>{skillEditFormData.formData.filePath}</div>
+                    <div>{currentData.filePath}</div>
                   </DescriptionListDescription>
                 </DescriptionListGroup>
               ]}
@@ -95,7 +101,7 @@ const ViewSkill: React.FC<ViewSkillProps> = ({ skillEditFormData }) => {
                 <DescriptionListGroup key="examples">
                   <DescriptionListTerm>Examples</DescriptionListTerm>
                   <DescriptionListDescription>
-                    <SkillSeedExamples seedExamples={skillEditFormData.formData.seedExamples} />
+                    <SkillSeedExamples seedExamples={currentData.seedExamples} />
                   </DescriptionListDescription>
                 </DescriptionListGroup>
               ]}

--- a/src/components/Dashboard/ContributionActions.tsx
+++ b/src/components/Dashboard/ContributionActions.tsx
@@ -50,9 +50,7 @@ const ContributionActions: React.FC<Props> = ({ contribution, onUpdateContributi
   const deleteRef = React.useRef<HTMLButtonElement>(null);
 
   const handleEditContribution = () => {
-    router.push(
-      `/contribute/${contribution.isKnowledge ? 'knowledge' : 'skill'}/edit/${contribution.branchName}${contribution.isDraft ? '/isDraft' : ''}`
-    );
+    router.push(`/contribute/${contribution.isKnowledge ? 'knowledge' : 'skill'}/edit/${contribution.branchName}`);
   };
 
   const deleteContribution = async (branchName: string) => {

--- a/src/components/Dashboard/ContributionCard.tsx
+++ b/src/components/Dashboard/ContributionCard.tsx
@@ -55,11 +55,7 @@ const ContributionCard: React.FC<Props> = ({ contribution, onUpdateContributions
                         component="a"
                         variant="link"
                         isInline
-                        onClick={() =>
-                          router.push(
-                            `/contribute/${contribution.isKnowledge ? 'knowledge' : 'skill'}/${contribution.branchName}${contribution.isDraft ? '/isDraft' : ''}`
-                          )
-                        }
+                        onClick={() => router.push(`/contribute/${contribution.isKnowledge ? 'knowledge' : 'skill'}/${contribution.branchName}`)}
                       >
                         <TruncatedText maxLines={2} content={contribution.title} />
                       </Button>

--- a/src/components/Dashboard/ContributionTableRow.tsx
+++ b/src/components/Dashboard/ContributionTableRow.tsx
@@ -28,11 +28,7 @@ const ContributionTableRow: React.FC<Props> = ({ contribution, onUpdateContribut
                 <Button
                   variant="link"
                   isInline
-                  onClick={() =>
-                    router.push(
-                      `/contribute/${contribution.isKnowledge ? 'knowledge' : 'skill'}/${contribution.branchName}${contribution.isDraft ? '/isDraft' : ''}`
-                    )
-                  }
+                  onClick={() => router.push(`/contribute/${contribution.isKnowledge ? 'knowledge' : 'skill'}/${contribution.branchName}`)}
                 >
                   <TruncatedText maxLines={2} content={contribution.title} />
                 </Button>

--- a/src/components/Dashboard/DashboardPage.tsx
+++ b/src/components/Dashboard/DashboardPage.tsx
@@ -144,7 +144,7 @@ const DashboardPage: React.FunctionComponent = () => {
           lastUpdated: new Date(draft.lastUpdated),
           isDraft: true,
           isKnowledge: draft.isKnowledgeDraft,
-          isSubmitted: draft.isSubmitted,
+          isSubmitted: false,
           state: 'draft',
           taxonomy: draft.taxonomy
         })),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,7 +14,6 @@ export interface DraftEditFormInfo {
   author?: string;
   lastUpdated: string;
   isKnowledgeDraft: boolean;
-  isSubmitted: boolean;
   oldFilesPath: string;
   taxonomy: string;
 }


### PR DESCRIPTION
### Description

- Removes the need for the `isDraft` query item in the URL.
- View/Edit pages check for a draft and use it if found.
- Updates the draft save/create based on changes to the current contribution/draft. This removes drafts that do not differ from the submitted contribution.
